### PR TITLE
新增隐藏桌面图标功能

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,12 @@
 
         <activity
             android:name=".SettingsActivity"
-            android:exported="true" />
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.INFO" />
+            </intent-filter>
+        </activity>
 
         <provider
             android:name=".ModuleSettingsProvider"

--- a/app/src/main/java/io/github/bbzq/BbzqApplication.kt
+++ b/app/src/main/java/io/github/bbzq/BbzqApplication.kt
@@ -6,5 +6,12 @@ class BbzqApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         ModuleRemotePreferences.init(this)
+        applyDesktopIconSetting()
+    }
+
+    private fun applyDesktopIconSetting() {
+        val prefs = getSharedPreferences(ModuleSettings.PREFS_NAME, MODE_PRIVATE)
+        val hideIcon = ModuleSettings.isHideDesktopIconEnabled(prefs)
+        DesktopIconHelper.applySetting(this, hideIcon)
     }
 }

--- a/app/src/main/java/io/github/bbzq/DesktopIconHelper.kt
+++ b/app/src/main/java/io/github/bbzq/DesktopIconHelper.kt
@@ -1,0 +1,24 @@
+package io.github.bbzq
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+
+object DesktopIconHelper {
+    private const val LAUNCHER_ACTIVITY = "io.github.bbzq.IntroActivity"
+
+    fun applySetting(context: Context, hide: Boolean) {
+        val component = ComponentName(context, LAUNCHER_ACTIVITY)
+        val pm = context.packageManager
+        val newState = if (hide) {
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        } else {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        }
+        pm.setComponentEnabledSetting(
+            component,
+            newState,
+            PackageManager.DONT_KILL_APP,
+        )
+    }
+}

--- a/app/src/main/java/io/github/bbzq/ModuleSettings.kt
+++ b/app/src/main/java/io/github/bbzq/ModuleSettings.kt
@@ -42,6 +42,7 @@ object ModuleSettings {
     const val KEY_FULL_NUMBER_FORMAT_ENABLED = "full_number_format_enabled"
     const val KEY_UNLOCK_COMMENT_GIF_ENABLED = "unlock_comment_gif_enabled"
     const val KEY_LAST_ACCESS_KEY = "last_access_key"
+    const val KEY_HIDE_DESKTOP_ICON = "hide_desktop_icon"
 
     const val KEY_TARGET_APP_VERSION = "target_app_version"
     const val CACHE_BILI_SETTINGS_ACTIVITY = "cache_settings_activity"
@@ -221,6 +222,9 @@ object ModuleSettings {
 
     fun isUnlockCommentGifEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(KEY_UNLOCK_COMMENT_GIF_ENABLED, false)
+
+    fun isHideDesktopIconEnabled(prefs: SharedPreferences): Boolean =
+        prefs.getBoolean(KEY_HIDE_DESKTOP_ICON, false)
 }
 
 enum class SkipVideoAdMode(val value: Int, val label: String) {

--- a/app/src/main/java/io/github/bbzq/SettingsContentFactory.kt
+++ b/app/src/main/java/io/github/bbzq/SettingsContentFactory.kt
@@ -21,6 +21,7 @@ import android.widget.ScrollView
 import android.widget.Switch
 import android.widget.TextView
 import android.widget.Toast
+import io.github.bbzq.DesktopIconHelper
 import io.github.bbzq.R
 
 class SettingsContentFactory(
@@ -372,6 +373,12 @@ class SettingsContentFactory(
 
     private fun aboutRows(): List<View> {
         val rows = mutableListOf<View>()
+        rows += createSwitchRow(
+            context.getString(R.string.about_hide_desktop_icon_title),
+            context.getString(R.string.about_hide_desktop_icon_summary),
+            ModuleSettings.KEY_HIDE_DESKTOP_ICON,
+            false,
+        )
         rows += createClickableInfoRow(
             context.getString(R.string.about_version_title),
             RuntimeEnvironmentInfo.versionSummary(context, prefs),
@@ -740,6 +747,14 @@ class SettingsContentFactory(
                         key == ModuleSettings.KEY_CUSTOM_HOME_COMPONENT_HIDE_ENABLED
                     ) {
                         refresh()
+                    }
+                    if (key == ModuleSettings.KEY_HIDE_DESKTOP_ICON) {
+                        if (isChecked) {
+                            DesktopIconHelper.applySetting(context, true)
+                        } else {
+                            DesktopIconHelper.applySetting(context, false)
+                            Toast.makeText(context, "回复图标需重启手机后生效", Toast.LENGTH_SHORT).show()
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
 
     <!-- 關於頁 -->
     <string name="about_version_title">版本</string>
+    <string name="about_hide_desktop_icon_title">隐藏桌面图标</string>
+    <string name="about_hide_desktop_icon_summary">隐藏后可通过B站内设置打开。(须在LSPosed中关闭“强制显示桌面图标”)</string>
     <string name="about_hidden_features_title">隐藏功能</string>
     <string name="about_hidden_features_summary">%1$s 隐藏功能已显示。</string>
     <string name="about_skip_video_ad_switch_title">空降助手功能开关</string>


### PR DESCRIPTION
feat: 新增桌面图标隐藏功能

具体修改：
   - ModuleSettings.kt: 添加 KEY_HIDE_DESKTOP_ICON 配置键及 isHideDesktopIconEnabled() 辅助函数
   - SettingsContentFactory.kt: 新增"隐藏桌面图标"开关
   - strings.xml
   - DesktopIconHelper.kt: 使用 PackageManager.setComponentEnabledSetting() 控制 IntroActivity 组件的启用/禁用状态
   - BbzqApplication.kt: onCreate() 中调用 applyDesktopIconSetting() 启动时自动应用设置
   - AndroidManifest.xml: 为 SettingsActivity 添加 MAIN + INFO intent-filter，使其独立响应 LSPosed "模块设置"功能
   - IntroActivity: 保留 MAIN + LAUNCHER intent-filter 作为桌面图标入口
   - 隐藏桌面图标仅作用于 IntroActivity，SettingsActivity 不受影响
   
本次PR部分参考了AI回答，但推送者已检查修改未包括模块其他功能，新增功能经过本地测试可以正常运行。