### PR TITLE
新增：设置页检查更新功能

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-sdk tools:overrideLibrary="io.github.libxposed.service,io.github.libxposed.service.interfaces" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <queries>
         <package android:name="tv.danmaku.bili" />
         <package android:name="com.bilibili.app.in" />

--- a/app/src/main/java/io/github/bbzq/MarkdownFormatter.kt
+++ b/app/src/main/java/io/github/bbzq/MarkdownFormatter.kt
@@ -1,0 +1,131 @@
+package io.github.bbzq
+
+import android.text.Html
+import android.text.Spanned
+
+/**
+ * 将 GitHub Release 的轻量 Markdown 转换为可在 TextView / AlertDialog 中渲染的富文本。
+ *
+ * 支持：# / ## / ### 标题（映射为 h2/h3/h4，呈现字号层次）、有序与无序列表、
+ * 引用、加粗、行内代码、链接。仅覆盖 Release Notes 常见语法，不追求完整 Markdown 兼容。
+ */
+object MarkdownFormatter {
+
+    fun toSpanned(markdown: String): Spanned {
+        val html = toHtml(markdown)
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            Html.fromHtml(html, Html.FROM_HTML_MODE_COMPACT)
+        } else {
+            @Suppress("DEPRECATION")
+            Html.fromHtml(html)
+        }
+    }
+
+    private fun toHtml(markdown: String): String {
+        val htmlBuilder = StringBuilder()
+        val lines = markdown.replace("\r\n", "\n").replace('\r', '\n').split('\n')
+        for (rawLine in lines) {
+            val line = rawLine.trim()
+            when {
+                line.isEmpty() -> htmlBuilder.append("<br>")
+
+                // 标题用 h 标签获得字号层次（h2>h3>h4，自带加粗与段落间距），不再额外加 <br>。
+                line.startsWith("### ") ->
+                    htmlBuilder.append("<h4>").append(inline(line.removePrefix("### "))).append("</h4>")
+
+                line.startsWith("## ") ->
+                    htmlBuilder.append("<h3>").append(inline(line.removePrefix("## "))).append("</h3>")
+
+                line.startsWith("# ") ->
+                    htmlBuilder.append("<h2>").append(inline(line.removePrefix("# "))).append("</h2>")
+
+                line.startsWith("> ") ->
+                    htmlBuilder.append("<i>").append(inline(line.removePrefix("> "))).append("</i><br>")
+
+                line.startsWith("- ") || line.startsWith("* ") ->
+                    htmlBuilder.append("&nbsp;&nbsp;•&nbsp;").append(inline(line.substring(2))).append("<br>")
+
+                ORDERED_LIST_REGEX.containsMatchIn(line) ->
+                    htmlBuilder.append("&nbsp;&nbsp;").append(inline(line)).append("<br>")
+
+                else -> htmlBuilder.append(inline(line)).append("<br>")
+            }
+        }
+        return htmlBuilder.toString()
+    }
+
+    /**
+     * 处理行内语法。先把行内代码、链接抽成占位符（其原始内容只在抽取时转义一次，
+     * 不再参与后续整体转义与加粗解析），再对剩余文本统一转义、处理加粗，最后回填占位符。
+     * 这样可避免链接 URL 被二次转义（如 query string 中的 & 变成 &amp;amp;）。
+     */
+    private fun inline(text: String): String {
+        // 先剥离正文里可能存在的占位符标记，防止被伪造（含字面 U+0001 的内容否则会被当作占位符匹配并注入）。
+        val sanitized = text.replace(PLACEHOLDER_MARK, "")
+        // 暂存被抽取的行内代码/链接 HTML，下标即占位符编号。
+        val stashedTokens = ArrayList<String>()
+        fun stash(html: String): String {
+            val placeholder = "$PLACEHOLDER_MARK${stashedTokens.size}$PLACEHOLDER_MARK"
+            stashedTokens += html
+            return placeholder
+        }
+
+        // 1. 行内代码：内容原样转义，不再参与链接/加粗解析。
+        var working = CODE_REGEX.replace(sanitized) { match -> stash("<tt>${escapeHtml(match.groupValues[1])}</tt>") }
+        // 2. 链接：在整体转义前抽取，label 继续解析加粗、URL 与 label 各只转义一次；非 http(s) 链接降级为纯文本。
+        working = LINK_REGEX.replace(working) { match ->
+            val label = match.groupValues[1]
+            val url = match.groupValues[2]
+            if (isSafeUrl(url)) {
+                stash("<a href=\"${escapeHtml(url)}\">${formatLabel(label)}</a>")
+            } else {
+                formatLabel(label)
+            }
+        }
+        // 3. 其余文本统一转义。
+        working = escapeHtml(working)
+        // 4. **粗体**
+        working = applyBold(working)
+        // 5. 倒序回填：外层 token（如链接）的 html 可能内嵌更早抽取的占位符（如 label 里的行内代码），
+        //    倒序保证外层先回填、把内嵌占位符暴露出来后再被替换，避免遗留无法回填的占位符。
+        for (index in stashedTokens.indices.reversed()) {
+            working = working.replace("$PLACEHOLDER_MARK$index$PLACEHOLDER_MARK", stashedTokens[index])
+        }
+        return working
+    }
+
+    /** 处理链接 label：整体转义后再解析其中的 **加粗**，使 label 内的加粗也能渲染。 */
+    private fun formatLabel(label: String): String = applyBold(escapeHtml(label))
+
+    private fun applyBold(text: String): String =
+        BOLD_REGEX.replace(text) { match -> "<b>${match.groupValues[1]}</b>" }
+
+    /** 仅允许 http/https 链接，其余（javascript:、data: 等）一律视为不安全。 */
+    private fun isSafeUrl(url: String): Boolean {
+        val normalizedUrl = url.trim().lowercase()
+        return normalizedUrl.startsWith("http://") || normalizedUrl.startsWith("https://")
+    }
+
+    /** 转义 HTML 关键字符，避免正文破坏标签结构。 */
+    private fun escapeHtml(text: String): String =
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+
+    /** 行内代码占位符标记，使用控制字符，确保不与正文及 HTML 转义冲突。 */
+    private const val PLACEHOLDER_MARK = "\u0001"
+
+    /** 链接语法 `[文本](URL)`。 */
+    private val LINK_REGEX = Regex("""\[([^\]]+)]\(([^)]+)\)""")
+
+    /** 加粗语法 `**文本**`。 */
+    private val BOLD_REGEX = Regex("""\*\*([^*]+)\*\*""")
+
+    /** 行内代码语法 `` `文本` ``。 */
+    private val CODE_REGEX = Regex("""`([^`]+)`""")
+
+    /** 有序列表行首，如 `1. `。 */
+    private val ORDERED_LIST_REGEX = Regex("""^\d+\.\s""")
+}
+

--- a/app/src/main/java/io/github/bbzq/ModuleSettings.kt
+++ b/app/src/main/java/io/github/bbzq/ModuleSettings.kt
@@ -63,6 +63,7 @@ object ModuleSettings {
     const val KEY_UNLOCK_COMMENT_GIF_ENABLED = "unlock_comment_gif_enabled"
     const val KEY_LAST_ACCESS_KEY = "last_access_key"
     const val KEY_HIDE_DESKTOP_ICON = "hide_desktop_icon"
+    const val KEY_ACCEPT_PRERELEASE_UPDATE = "accept_prerelease_update"
     const val KEY_COMMENT_DISABLE = "vid_comment_disable"
     const val KEY_COMMENT_NO_QUICK_REPLY = "vid_comment_no_quick_reply"
     const val KEY_COMMENT_NO_VOTE = "vid_comment_no_vote"
@@ -227,6 +228,7 @@ object ModuleSettings {
         ExportableConfigSpec(KEY_FULL_NUMBER_FORMAT_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_FULL_NUMBER_FORMAT_ENABLED, false) },
         ExportableConfigSpec(KEY_UNLOCK_COMMENT_GIF_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_UNLOCK_COMMENT_GIF_ENABLED, false) },
         ExportableConfigSpec(KEY_HIDE_DESKTOP_ICON, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_HIDE_DESKTOP_ICON, false) },
+        ExportableConfigSpec(KEY_ACCEPT_PRERELEASE_UPDATE, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_ACCEPT_PRERELEASE_UPDATE, false) },
         ExportableConfigSpec(KEY_COMMENT_DISABLE, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_COMMENT_DISABLE, false) },
         ExportableConfigSpec(KEY_COMMENT_NO_QUICK_REPLY, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_COMMENT_NO_QUICK_REPLY, false) },
         ExportableConfigSpec(KEY_COMMENT_NO_VOTE, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_COMMENT_NO_VOTE, false) },
@@ -519,6 +521,9 @@ object ModuleSettings {
 
     fun isHideDesktopIconEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(KEY_HIDE_DESKTOP_ICON, false)
+
+    fun isAcceptPrereleaseUpdateEnabled(prefs: SharedPreferences): Boolean =
+        prefs.getBoolean(KEY_ACCEPT_PRERELEASE_UPDATE, false)
 
     fun isCommentDisableEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(KEY_COMMENT_DISABLE, false)

--- a/app/src/main/java/io/github/bbzq/SettingsActivity.kt
+++ b/app/src/main/java/io/github/bbzq/SettingsActivity.kt
@@ -26,6 +26,7 @@ class SettingsActivity : Activity() {
     }
 
     private var pendingImportArchive: ByteArray? = null
+    private var contentFactory: SettingsContentFactory? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,7 +35,7 @@ class SettingsActivity : Activity() {
 
         val page = intent.getStringExtra(EXTRA_PAGE) ?: PAGE_ROOT
         val toolbar = createToolbar(page)
-        val content = SettingsContentFactory(
+        val factory = SettingsContentFactory(
             context = this,
             prefs = prefs,
             page = page,
@@ -47,7 +48,9 @@ class SettingsActivity : Activity() {
             },
             onExportClick = { launchExportConfig() },
             onImportClick = { launchImportConfig() },
-        ).createScrollView()
+        )
+        contentFactory = factory
+        val content = factory.createScrollView()
         val root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setBackgroundColor(Color.parseColor("#F6F7F8"))
@@ -63,6 +66,12 @@ class SettingsActivity : Activity() {
 
         setContentView(root)
         applyWindowInsets(root, toolbar, content)
+    }
+
+    override fun onDestroy() {
+        contentFactory?.destroy()
+        contentFactory = null
+        super.onDestroy()
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/io/github/bbzq/SettingsContentFactory.kt
+++ b/app/src/main/java/io/github/bbzq/SettingsContentFactory.kt
@@ -11,6 +11,8 @@ import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.SystemClock
 import android.text.InputType
+import android.text.SpannableString
+import android.text.method.LinkMovementMethod
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -27,6 +29,7 @@ import android.widget.TextView
 import android.widget.Toast
 import io.github.bbzq.DesktopIconHelper
 import io.github.bbzq.R
+import okhttp3.Call
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -64,6 +67,14 @@ class SettingsContentFactory(
     private lateinit var skipVideoAdAutoLikeSwitch: Switch
     private lateinit var blockedCountView: TextView
     private lateinit var symbolScanStatusSummary: TextView
+    /** 「检查更新」行的摘要文本视图，用于回显检查状态；界面销毁时置空避免泄漏。 */
+    private var updateCheckSummaryView: TextView? = null
+
+    /** 是否正在检查更新，用于去重并发点击。 */
+    private var updateChecking = false
+
+    /** 当前在途的检查更新请求，界面销毁时取消。 */
+    private var updateCheckCall: Call? = null
     private var versionTapCount = 0
     private var firstVersionTapAt = 0L
     private var refreshing = false
@@ -110,9 +121,6 @@ class SettingsContentFactory(
 
                 pageRoot.addView(createSectionLabel(context.getString(R.string.section_home_recommend_purify)))
                 pageRoot.addView(createSectionCard(homeRecommendRows()))
-
-                pageRoot.addView(createSectionLabel(context.getString(R.string.section_dynamic_page)))
-                pageRoot.addView(createSectionCard(dynamicRows()))
 
                 pageRoot.addView(createSectionLabel(context.getString(R.string.section_ui_customize)))
                 pageRoot.addView(createSectionCard(bottomBarRows()))
@@ -325,29 +333,6 @@ class SettingsContentFactory(
             rows += createHomeComponentGroup(components)
         }
         return rows
-    }
-
-    private fun dynamicRows(): List<View> {
-        return listOf(
-            createSwitchRow(
-                context.getString(R.string.dynamic_preferred_video_tab_title),
-                context.getString(R.string.dynamic_preferred_video_tab_summary),
-                ModuleSettings.KEY_DYNAMIC_PREFERRED_VIDEO_TAB_ENABLED,
-                false,
-            ),
-            createSwitchRow(
-                context.getString(R.string.dynamic_remove_city_tab_title),
-                context.getString(R.string.dynamic_remove_city_tab_summary),
-                ModuleSettings.KEY_DYNAMIC_REMOVE_CITY_TAB_ENABLED,
-                false,
-            ),
-            createSwitchRow(
-                context.getString(R.string.dynamic_remove_school_tab_title),
-                context.getString(R.string.dynamic_remove_school_tab_summary),
-                ModuleSettings.KEY_DYNAMIC_REMOVE_SCHOOL_TAB_ENABLED,
-                false,
-            ),
-        )
     }
 
     private fun bottomBarRows(): List<View> {
@@ -607,6 +592,13 @@ class SettingsContentFactory(
         ) {
             handleVersionRowClick()
         }
+        rows += createUpdateCheckRow()
+        rows += createSwitchRow(
+            context.getString(R.string.about_accept_prerelease_title),
+            context.getString(R.string.about_accept_prerelease_summary),
+            ModuleSettings.KEY_ACCEPT_PRERELEASE_UPDATE,
+            false,
+        )
         rows += createClickableInfoRow(
             context.getString(R.string.about_export_config_title),
             context.getString(R.string.about_export_config_summary),
@@ -724,6 +716,150 @@ class SettingsContentFactory(
         ModuleSettings.isSkipVideoAdSettingsVisible(prefs) ||
             ModuleSettings.isAccessKeySettingsVisible(prefs) ||
             ModuleSettings.isTryFreeQualitySettingsVisible(prefs)
+
+    private fun createUpdateCheckRow(): View {
+        val summaryView = TextView(context).apply {
+            text = context.getString(R.string.about_check_update_summary)
+            textSize = 12f
+            setTextColor(SUMMARY_COLOR)
+            setPadding(0, dp(4), 0, 0)
+        }
+        updateCheckSummaryView = summaryView
+        return LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { handleUpdateCheckClick() }
+            addView(TextView(context).apply {
+                text = context.getString(R.string.about_check_update_title)
+                textSize = 15f
+                setTextColor(TITLE_COLOR)
+            })
+            addView(summaryView)
+        }
+    }
+
+    private fun handleUpdateCheckClick() {
+        if (updateChecking) return
+        updateChecking = true
+        updateCheckSummaryView?.text = context.getString(R.string.check_update_checking_summary)
+        updateCheckCall = UpdateChecker.check(
+            BuildConfig.RELEASE_NAME,
+            BuildConfig.VERSION_CODE,
+            ModuleSettings.isAcceptPrereleaseUpdateEnabled(prefs),
+        ) { result ->
+            updateCheckCall = null
+            updateChecking = false
+            if (isActivityFinishing()) return@check
+            onUpdateCheckResult(result)
+        }
+    }
+
+    /** 界面销毁时调用：取消在途请求并断开视图引用，避免回调持有已销毁的 Activity。 */
+    fun destroy() {
+        updateCheckCall?.cancel()
+        updateCheckCall = null
+        updateCheckSummaryView = null
+    }
+
+    private fun onUpdateCheckResult(result: UpdateChecker.Result) {
+        when (result.status) {
+            UpdateChecker.Status.UP_TO_DATE -> {
+                updateCheckSummaryView?.text = context.getString(
+                    R.string.check_update_up_to_date_summary,
+                    result.latestVersion ?: BuildConfig.RELEASE_NAME,
+                )
+            }
+
+            UpdateChecker.Status.UPDATE_AVAILABLE -> {
+                val latest = result.latestVersion.orEmpty()
+                updateCheckSummaryView?.text = context.getString(
+                    R.string.check_update_available_summary,
+                    latest,
+                )
+                showUpdateAvailableDialog(result)
+            }
+
+            UpdateChecker.Status.FAILED -> {
+                updateCheckSummaryView?.text = context.getString(R.string.check_update_failed_summary)
+            }
+        }
+    }
+
+    private fun showUpdateAvailableDialog(result: UpdateChecker.Result) {
+        val latestVersionText = formatVersionWithCode(result.latestVersion.orEmpty(), result.latestVersionCode)
+        val currentVersionText = formatVersionWithCode(
+            result.currentVersion ?: BuildConfig.RELEASE_NAME,
+            BuildConfig.VERSION_CODE,
+        )
+        val header = buildString {
+            append(
+                context.getString(
+                    R.string.check_update_dialog_message,
+                    latestVersionText,
+                    currentVersionText,
+                ),
+            )
+            if (result.apkSizeBytes > 0) {
+                append('\n')
+                append(context.getString(R.string.check_update_apk_size, formatSize(result.apkSizeBytes)))
+            }
+        }
+        val notesRaw = result.releaseNotes?.takeIf { it.isNotBlank() }
+        val notesSpanned = notesRaw?.let { MarkdownFormatter.toSpanned(it) }
+            ?: SpannableString(context.getString(R.string.check_update_notes_empty))
+
+        val content = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(12), dp(20), 0)
+            addView(TextView(context).apply {
+                text = header
+                textSize = 14f
+                setTextColor(TITLE_COLOR)
+            })
+            addView(TextView(context).apply {
+                text = context.getString(R.string.check_update_notes_label)
+                textSize = 12f
+                setTextColor(SUMMARY_COLOR)
+                setPadding(0, dp(12), 0, dp(4))
+            })
+            addView(TextView(context).apply {
+                text = notesSpanned
+                textSize = 13f
+                setTextColor(TITLE_COLOR)
+                movementMethod = LinkMovementMethod.getInstance()
+            })
+        }
+        val scroll = ScrollView(context).apply { addView(content) }
+
+        AlertDialog.Builder(context)
+            .setTitle(R.string.check_update_dialog_title)
+            .setView(scroll)
+            .setNegativeButton(R.string.dialog_cancel, null)
+            .setPositiveButton(R.string.check_update_dialog_confirm) { _, _ ->
+                openUrl(result.releaseUrl ?: RELEASE_PAGE_URL)
+            }
+            .show()
+    }
+
+    /** 拼接「版本号（versionCode）」，code 无效时只显示版本号。 */
+    private fun formatVersionWithCode(version: String, code: Int): String =
+        if (code > 0) {
+            context.getString(R.string.check_update_version_with_code, version, code)
+        } else {
+            version
+        }
+
+    /** 将字节数格式化为可读大小（KB/MB）。 */
+    private fun formatSize(bytes: Long): String {
+        val kb = bytes / 1024.0
+        return if (kb < 1024) {
+            String.format(Locale.getDefault(), "%.1f KB", kb)
+        } else {
+            String.format(Locale.getDefault(), "%.1f MB", kb / 1024.0)
+        }
+    }
 
     private fun handleAccessKeyClick() {
         val key = AccessKeyRepository.read(prefs)
@@ -1700,5 +1836,8 @@ class SettingsContentFactory(
         private val CANCEL_ACTION_COLOR = Color.parseColor("#00A1D6")
         private const val VERSION_TAP_WINDOW_MS = 1500L
         private const val TITLE_KEYWORD_SUMMARY_MAX_ITEMS = 4
+        /** 检查更新弹窗「前往下载」的兜底地址，当 Release 未给出链接时使用。 */
+        private const val RELEASE_PAGE_URL =
+            "https://github.com/Xposed-Modules-Repo/io.github.bbzq/releases/latest"
     }
 }

--- a/app/src/main/java/io/github/bbzq/UpdateChecker.kt
+++ b/app/src/main/java/io/github/bbzq/UpdateChecker.kt
@@ -1,0 +1,309 @@
+package io.github.bbzq
+
+import android.os.Handler
+import android.os.Looper
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * 通过 LSPosed 模块仓库的 GitHub Release API 检查模组是否有新版本。
+ *
+ * 先按发布通道过滤（默认仅正式版；接收测试版时纳入 prerelease），再取最新 Release
+ * 与当前版本比较，判定优先级：
+ * 1. versionCode（两端均可解析时）：最新版 > 当前版 → 有更新；
+ * 2. 版本号（versionName）：最新版版本号更高 → 有更新；
+ * 3. 其余情况（版本号相同或更低）→ 已是最新。
+ *
+ * versionCode 取自 tag_name 开头的数字（如 133-v1.0.3-133 → 133），versionName 优先取 tag_name
+ * （剥离 versionCode 前后缀，name 字段作为备选），
+ * 更新日志取 body，安装包大小取 APK 资产的 size。
+ *
+ * 结果回调统一切回主线程，便于直接更新 UI。
+ */
+object UpdateChecker {
+
+    /** 一次检查更新的结果。 */
+    data class Result(
+        /** 检查结果状态：已最新 / 有更新 / 失败 */
+        val status: Status,
+        /** 最新 Release 的版本名（已规范化，如 1.0.3），失败时为 null */
+        val latestVersion: String? = null,
+        /** 本地当前版本名（BuildConfig.RELEASE_NAME），便于回显 */
+        val currentVersion: String? = null,
+        /** 最新 Release 的下载/详情页地址，无则为 null */
+        val releaseUrl: String? = null,
+        /** 最新 Release 的更新日志（release body），无内容时为 null */
+        val releaseNotes: String? = null,
+        /** 最新 Release 的 versionCode，无法解析时为 0 */
+        val latestVersionCode: Int = 0,
+        /** 最新 Release 的 APK 安装包大小（字节），无则为 0 */
+        val apkSizeBytes: Long = 0,
+    )
+
+    enum class Status {
+        /** 已是最新版本 */
+        UP_TO_DATE,
+        /** 发现新版本 */
+        UPDATE_AVAILABLE,
+        /** 网络或解析失败 */
+        FAILED,
+    }
+
+    /** 单个 Release 的精简信息。 */
+    private data class ReleaseInfo(
+        /** 版本名（优先取自 tag_name，name 字段为备选，如 v1.0.3） */
+        val versionName: String,
+        /** Release 详情页地址（来自 html_url） */
+        val htmlUrl: String,
+        /** 更新日志原文（来自 body） */
+        val body: String,
+        /** 从 tag_name 开头数字解析出的 versionCode，无则为 0 */
+        val versionCode: Int,
+        /** APK 安装包大小（字节），无则为 0 */
+        val apkSizeBytes: Long,
+        /** 是否为预发布（测试）版本 */
+        val prerelease: Boolean,
+    )
+
+    /** 用于把异步结果切回主线程的主线程 Handler。 */
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** 检查更新专用的 OkHttp 客户端，懒加载，连接/读取均限时 10 秒。 */
+    private val httpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+    }
+
+    /**
+     * @param currentVersion 本地版本号（BuildConfig.RELEASE_NAME）
+     * @param currentVersionCode 本地 versionCode（BuildConfig.VERSION_CODE），0 或负值表示不参与比较
+     * @param acceptPrerelease 是否接收预发布（测试）版本更新
+     * @return 本次请求的 [Call]，调用方可在界面销毁时 cancel 以释放回调、避免泄漏；构造失败时为 null
+     */
+    fun check(
+        currentVersion: String,
+        currentVersionCode: Int,
+        acceptPrerelease: Boolean,
+        onResult: (Result) -> Unit,
+    ): Call? {
+        // 同步兜底：构造请求或入队若抛出异常（如客户端初始化失败、调度器拒绝），
+        // 也要回调一次失败，避免调用方状态永久卡住。
+        return try {
+            val request = Request.Builder()
+                .url(RELEASE_API_URL)
+                .header("accept", "application/vnd.github+json")
+                .header("user-agent", USER_AGENT)
+                .build()
+
+            val call = httpClient.newCall(request)
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    postResult(onResult, Result(Status.FAILED, currentVersion = currentVersion))
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    // 整体兜底：读取 body 或解析期间的任何异常都不应使回调丢失，
+                    // 否则调用方的 updateChecking 状态会永久卡住。
+                    val result = try {
+                        response.use { parseResponse(it, currentVersion, currentVersionCode, acceptPrerelease) }
+                    } catch (_: Throwable) {
+                        Result(Status.FAILED, currentVersion = currentVersion)
+                    }
+                    postResult(onResult, result)
+                }
+            })
+            call
+        } catch (_: Throwable) {
+            postResult(onResult, Result(Status.FAILED, currentVersion = currentVersion))
+            null
+        }
+    }
+
+    private fun parseResponse(
+        response: Response,
+        currentVersion: String,
+        currentVersionCode: Int,
+        acceptPrerelease: Boolean,
+    ): Result {
+        if (!response.isSuccessful) {
+            return Result(Status.FAILED, currentVersion = currentVersion)
+        }
+        val body = response.body.string()
+        if (body.isBlank()) {
+            return Result(Status.FAILED, currentVersion = currentVersion)
+        }
+        val allReleases = parseReleases(body)
+        if (allReleases.isEmpty()) {
+            return Result(Status.FAILED, currentVersion = currentVersion)
+        }
+        // 发布通道过滤：未接收测试版时仅保留正式版。
+        val releases = if (acceptPrerelease) allReleases else allReleases.filterNot { it.prerelease }
+        if (releases.isEmpty()) {
+            return Result(Status.UP_TO_DATE, currentVersion = currentVersion)
+        }
+
+        // 优先按 versionCode、其次按版本号选出最新 Release。
+        val latest = releases.maxWithOrNull { left, right -> compareRelease(left, right) }
+            ?: return Result(Status.FAILED, currentVersion = currentVersion)
+
+        val hasUpdate = hasUpdate(latest, currentVersion, currentVersionCode)
+        val status = if (hasUpdate) Status.UPDATE_AVAILABLE else Status.UP_TO_DATE
+        return Result(
+            status = status,
+            latestVersion = normalizeVersion(latest.versionName),
+            currentVersion = currentVersion,
+            releaseUrl = latest.htmlUrl,
+            releaseNotes = latest.body.trim().takeIf { it.isNotEmpty() },
+            latestVersionCode = latest.versionCode,
+            apkSizeBytes = latest.apkSizeBytes,
+        )
+    }
+
+    /**
+     * 判断是否有更新。
+     *
+     * - 两端 versionCode 均有效：直接以 versionCode 高低为准；
+     * - 否则按版本号：最新版版本号更高 → 有更新；
+     * - 其余情况（版本号相同或更低）→ 已是最新。
+     */
+    private fun hasUpdate(
+        latest: ReleaseInfo,
+        currentVersion: String,
+        currentVersionCode: Int,
+    ): Boolean {
+        if (latest.versionCode > 0 && currentVersionCode > 0) {
+            return latest.versionCode > currentVersionCode
+        }
+        return compareVersion(latest.versionName, currentVersion) > 0
+    }
+
+    /** 列表内排序用：先比 versionCode，缺失则比版本号。 */
+    private fun compareRelease(left: ReleaseInfo, right: ReleaseInfo): Int {
+        if (left.versionCode > 0 && right.versionCode > 0) {
+            return left.versionCode.compareTo(right.versionCode)
+        }
+        return compareVersion(left.versionName, right.versionName)
+    }
+
+    /** 解析 Release 列表，丢弃 draft 与无版本名的条目。 */
+    private fun parseReleases(body: String): List<ReleaseInfo> {
+        val releaseArray = JSONArray(body)
+        val releases = ArrayList<ReleaseInfo>(releaseArray.length())
+        for (index in 0 until releaseArray.length()) {
+            val releaseObject = releaseArray.optJSONObject(index) ?: continue
+            if (releaseObject.optBoolean("draft", false)) continue
+            val tagName = jsonString(releaseObject, "tag_name")
+            val versionCode = parseVersionCode(tagName)
+            // 版本名优先取 tag_name（剥离首尾 versionCode 前后缀，避免 `133-v1.0.3-133`
+            // 的数字前缀被当成主版本号），无法得出时退回 name 字段。
+            val versionName = versionNameFromTag(tagName, versionCode).ifBlank { jsonString(releaseObject, "name") }
+            if (versionName.isBlank()) continue
+            val htmlUrl = jsonString(releaseObject, "html_url").takeIf { it.isNotBlank() } ?: RELEASE_PAGE_URL
+            releases += ReleaseInfo(
+                versionName = versionName,
+                htmlUrl = htmlUrl,
+                body = jsonString(releaseObject, "body"),
+                versionCode = versionCode,
+                apkSizeBytes = parseApkSize(releaseObject),
+                prerelease = releaseObject.optBoolean("prerelease", false),
+            )
+        }
+        return releases
+    }
+
+    /**
+     * 从 tag_name 开头的数字解析 versionCode。
+     *
+     * LSPosed 仓库 tag 形如 `133-v1.0.3-133`，开头第一段即 versionCode；无则返回 0。
+     */
+    private fun parseVersionCode(tagName: String): Int =
+        tagName.substringBefore('-', "").toIntOrNull() ?: 0
+
+    /**
+     * 由 tag_name 推导可读版本名（版本名的首选来源）。
+     *
+     * LSPosed tag 形如 `133-v1.0.3-133`：先剥离开头的 versionCode 前缀，再剥离结尾的 `-133` 后缀，
+     * 得到 `v1.0.3`，避免数字前缀被 compareVersion 误当成主版本号。tag 为空时返回空串（交由调用方退回 name）。
+     */
+    private fun versionNameFromTag(tagName: String, versionCode: Int): String {
+        if (tagName.isBlank()) return ""
+        if (versionCode <= 0) return tagName
+        val codeText = versionCode.toString()
+        return tagName
+            .removePrefix("$codeText-")
+            .removeSuffix("-$codeText")
+            .ifBlank { tagName }
+    }
+
+    /** 读取字符串字段，JSON null 视为空串（org.json 的 optString 对 null 会返回字面 "null"）。 */
+    private fun jsonString(jsonObject: JSONObject, key: String): String =
+        if (jsonObject.isNull(key)) "" else jsonObject.optString(key)
+
+    /** 取 Release 中 APK 资产的大小（字节），多个时取最大值，无则返回 0。 */
+    private fun parseApkSize(release: JSONObject): Long {
+        val assets = release.optJSONArray("assets") ?: return 0
+        var maxSize = 0L
+        for (index in 0 until assets.length()) {
+            val asset = assets.optJSONObject(index) ?: continue
+            if (!asset.optString("name").endsWith(".apk", ignoreCase = true)) continue
+            val assetSize = asset.optLong("size", 0)
+            if (assetSize > maxSize) maxSize = assetSize
+        }
+        return maxSize
+    }
+
+    private fun postResult(onResult: (Result) -> Unit, result: Result) {
+        mainHandler.post { onResult(result) }
+    }
+
+    /** 比较语义化版本号：remote>local 返回 1，remote<local 返回 -1，相等返回 0。 */
+    private fun compareVersion(remote: String, local: String): Int {
+        val remoteParts = parseVersionParts(remote)
+        val localParts = parseVersionParts(local)
+        val partCount = maxOf(remoteParts.size, localParts.size)
+        for (index in 0 until partCount) {
+            val remotePart = remoteParts.getOrElse(index) { 0 }
+            val localPart = localParts.getOrElse(index) { 0 }
+            if (remotePart != localPart) return if (remotePart > localPart) 1 else -1
+        }
+        return 0
+    }
+
+    private fun parseVersionParts(version: String): List<Int> =
+        normalizeVersion(version)
+            .split('.')
+            .map { part -> part.takeWhile(Char::isDigit).toIntOrNull() ?: 0 }
+
+    /** 去掉前缀 v / V 与首尾空白（如 v1.0.3 → 1.0.3）。 */
+    private fun normalizeVersion(version: String): String =
+        version.trim()
+            .removePrefix("v")
+            .removePrefix("V")
+            .trim()
+
+    /** LSPosed 模块仓库的 Release 列表 API，单次最多取 30 条。 */
+    private const val RELEASE_API_URL =
+        "https://api.github.com/repos/Xposed-Modules-Repo/io.github.bbzq/releases?per_page=30"
+
+    /** Release 列表为空或缺少链接时，跳转的兜底 Release 页地址。 */
+    private const val RELEASE_PAGE_URL =
+        "https://github.com/Xposed-Modules-Repo/io.github.bbzq/releases/latest"
+
+    /** 请求头 User-Agent，GitHub API 要求携带。 */
+    private const val USER_AGENT = "BBZQ-UpdateChecker"
+
+    /** 建立连接的超时时间（秒）。 */
+    private const val CONNECT_TIMEOUT_SECONDS = 10L
+
+    /** 读取响应的超时时间（秒）。 */
+    private const val READ_TIMEOUT_SECONDS = 10L
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,21 @@
 
     <!-- 關於頁 -->
     <string name="about_version_title">版本</string>
+    <string name="about_check_update_title">检查更新</string>
+    <string name="about_check_update_summary">点击从 GitHub Release 检查是否有新版本。</string>
+    <string name="check_update_checking_summary">正在检查更新…</string>
+    <string name="check_update_up_to_date_summary">已是最新版本（%1$s）。</string>
+    <string name="check_update_available_summary">发现新版本 %1$s，点击前往下载。</string>
+    <string name="check_update_failed_summary">检查更新失败，请检查网络后重试。</string>
+    <string name="check_update_dialog_title">发现新版本</string>
+    <string name="check_update_dialog_message">最新版本：%1$s\n当前版本：%2$s</string>
+    <string name="check_update_version_with_code">%1$s（%2$d）</string>
+    <string name="check_update_notes_label">更新日志</string>
+    <string name="check_update_apk_size">安装包大小：%1$s</string>
+    <string name="check_update_notes_empty">（暂无更新日志）</string>
+    <string name="about_accept_prerelease_title">接收测试版更新</string>
+    <string name="about_accept_prerelease_summary">开启后检查更新将包含预发布（pre-release）版本。</string>
+    <string name="check_update_dialog_confirm">前往下载</string>
     <string name="about_export_config_title">导出配置</string>
     <string name="about_export_config_summary">以 ZIP 打包导出功能开关与手动配置，不包含数据或账户内容。</string>
     <string name="about_import_config_title">导入配置</string>


### PR DESCRIPTION
## 概述

在关于页新增「检查更新」卡片，从 LSPosed 模块仓库（`Xposed-Modules-Repo/io.github.bbzq`）的 GitHub Release 检查模块是否有新版本，并以弹窗展示版本信息与更新日志。

## 功能

- 关于页新增「检查更新」卡片，点击发起检查；过程中显示「正在检查更新…」状态
- 新增「接收测试版（pre-release）更新」开关，默认关闭
- 发现新版本时弹窗展示：最新版本号、versionCode、安装包大小，以及渲染后的更新日志
- 新增 `MarkdownFormatter`，将 Release Notes 的轻量 Markdown 渲染为富文本（标题、有序/无序列表、引用、加粗、行内代码、链接）

## 实现要点

- 版本判定优先级：versionCode 优先、版本号次之
- versionName 优先取自 `tag_name`（剥离 LSPosed tag 的 versionCode 前后缀，如 `133-v1.0.3-133` → `v1.0.3`），`name` 字段作为备选
- 请求基于 OkHttp 异步执行，结果统一切回主线程更新 UI
- 检查请求可取消：界面销毁时取消在途请求并断开视图引用，避免 Activity 泄漏与结果丢失
- 更新日志渲染对链接 URL、占位符回填、HTML 转义等做了安全处理（防二次转义、防占位符伪造、仅允许 http/https 链接）
- 新增 `android.permission.INTERNET` 权限（检查更新所需）

## 测试情况

- `:app:assembleDebug` / `:app:compileDebugKotlin` 构建通过
- 已打 debug 包实机验证：检查更新、更新日志 Markdown 渲染、测试版开关、检查过程中旋转屏幕/退出页面无卡死或闪退