### PR TITLE
feat: 修复自制主题在 API 33+ 失效的问题,并支持注入进度条图标与下拉刷新动画

### DIFF
--- a/app/src/main/java/io/github/bbzq/ModuleSettings.kt
+++ b/app/src/main/java/io/github/bbzq/ModuleSettings.kt
@@ -69,6 +69,7 @@ object ModuleSettings {
     const val KEY_SKIP_MINI_GAME_REWARD_AD_ENABLED = "skip_mini_game_reward_ad_enabled"
     const val KEY_BLOCK_LIVE_RESERVATION_ENABLED = "block_live_reservation_enabled"
     const val KEY_BLOCK_LIVE_ROOM_QOE_POPUP_ENABLED = "block_live_room_qoe_popup_enabled"
+    const val KEY_REMOVE_LIVE_ROOM_BLUR_MASK_ENABLED = "remove_live_room_blur_mask_enabled"
     const val KEY_DISABLE_LONG_PRESS_COPY_ENABLED = "disable_long_press_copy_enabled"
     const val KEY_ENHANCE_LONG_PRESS_COPY_ENABLED = "enhance_long_press_copy_enabled"
     const val KEY_CUSTOM_BOTTOM_BAR_ENABLED = "custom_bottom_bar_enabled"
@@ -286,6 +287,7 @@ object ModuleSettings {
         ExportableConfigSpec(KEY_SKIP_MINI_GAME_REWARD_AD_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_SKIP_MINI_GAME_REWARD_AD_ENABLED, true) },
         ExportableConfigSpec(KEY_BLOCK_LIVE_RESERVATION_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_BLOCK_LIVE_RESERVATION_ENABLED, false) },
         ExportableConfigSpec(KEY_BLOCK_LIVE_ROOM_QOE_POPUP_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_BLOCK_LIVE_ROOM_QOE_POPUP_ENABLED, false) },
+        ExportableConfigSpec(KEY_REMOVE_LIVE_ROOM_BLUR_MASK_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_REMOVE_LIVE_ROOM_BLUR_MASK_ENABLED, false) },
         ExportableConfigSpec(KEY_DISABLE_LONG_PRESS_COPY_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_DISABLE_LONG_PRESS_COPY_ENABLED, false) },
         ExportableConfigSpec(KEY_ENHANCE_LONG_PRESS_COPY_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_ENHANCE_LONG_PRESS_COPY_ENABLED, false) },
         ExportableConfigSpec(KEY_CUSTOM_BOTTOM_BAR_ENABLED, ExportableValueType.BOOLEAN) { it.getBoolean(KEY_CUSTOM_BOTTOM_BAR_ENABLED, false) },
@@ -764,6 +766,9 @@ object ModuleSettings {
 
     fun isBlockLiveRoomQoePopupEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(KEY_BLOCK_LIVE_ROOM_QOE_POPUP_ENABLED, false)
+
+    fun isRemoveLiveRoomBlurMaskEnabled(prefs: SharedPreferences): Boolean =
+        prefs.getBoolean(KEY_REMOVE_LIVE_ROOM_BLUR_MASK_ENABLED, false)
 
     fun isDisableLongPressCopyEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(KEY_DISABLE_LONG_PRESS_COPY_ENABLED, false)

--- a/app/src/main/java/io/github/bbzq/SettingsContentFactory.kt
+++ b/app/src/main/java/io/github/bbzq/SettingsContentFactory.kt
@@ -487,6 +487,24 @@ class SettingsContentFactory(
         ) {
             videoDetailRelateFilterSwitch = it
         }
+        rows += createSwitchRow(
+            context.getString(R.string.block_live_reservation_title),
+            context.getString(R.string.block_live_reservation_summary),
+            ModuleSettings.KEY_BLOCK_LIVE_RESERVATION_ENABLED,
+            false,
+        )
+        rows += createSwitchRow(
+            context.getString(R.string.block_live_room_qoe_popup_title),
+            context.getString(R.string.block_live_room_qoe_popup_summary),
+            ModuleSettings.KEY_BLOCK_LIVE_ROOM_QOE_POPUP_ENABLED,
+            false,
+        )
+        rows += createSwitchRow(
+            context.getString(R.string.remove_live_room_blur_mask_title),
+            context.getString(R.string.remove_live_room_blur_mask_summary),
+            ModuleSettings.KEY_REMOVE_LIVE_ROOM_BLUR_MASK_ENABLED,
+            false,
+        )
         rows += createVideoDetailRelateTitleKeywordRow()
         val relateTypes = videoDetailRelateTypes()
         if (relateTypes.isEmpty()) {

--- a/app/src/main/java/io/github/bbzq/feats/RoamingRuntime.kt
+++ b/app/src/main/java/io/github/bbzq/feats/RoamingRuntime.kt
@@ -48,6 +48,7 @@ import io.github.bbzq.feats.hook.LongPressSpeedLockHook
 import io.github.bbzq.feats.hook.ReadEraHook
 import io.github.bbzq.feats.hook.BlockActivityMetaStickerHook
 import io.github.bbzq.feats.hook.WoMicHook
+import io.github.bbzq.feats.hook.LiveRoomBlurMaskHook
 import io.github.bbzq.feats.symbol.BiliHookSymbols
 import io.github.bbzq.feats.symbol.BiliSymbolResolver
 import io.github.libxposed.api.XposedInterface
@@ -199,6 +200,7 @@ object RoamingRuntime {
                 ::MineProfileHook,
                 ::CustomThemeHook,
                 ::BlockActivityMetaStickerHook,
+                ::LiveRoomBlurMaskHook,
             )
             ProcessScope.UNSUPPORTED -> emptyList()
         }

--- a/app/src/main/java/io/github/bbzq/feats/RoamingRuntime.kt
+++ b/app/src/main/java/io/github/bbzq/feats/RoamingRuntime.kt
@@ -214,6 +214,9 @@ object RoamingRuntime {
         if (processScope == ProcessScope.WEB) {
             runCatching { CustomThemeHook(env).insertColorForWebProcess() }
                 .onFailure { env.log("CustomTheme web process hook failed", it) }
+            // web 进程渲染列表/评论区,下拉动画配置也要在这里写入
+            runCatching { CustomThemeHook(env).insertLoadEquipForWebProcess() }
+                .onFailure { env.log("CustomTheme web load equip hook failed", it) }
         }
 
         env.log("BBZQ runtime installed ${hooks.size} hook(s)")

--- a/app/src/main/java/io/github/bbzq/feats/hook/CustomSkinApplier.kt
+++ b/app/src/main/java/io/github/bbzq/feats/hook/CustomSkinApplier.kt
@@ -33,7 +33,20 @@ internal object CustomSkinApplier {
         if (config.isBlank()) return
         registerThemeChangeObserver(env)
         val target = resolveTarget(env, config) ?: return
-        if (isTargetApplied(target)) return
+        if (isTargetApplied(target)) {
+            // 已应用过:load_equip 仍要幂等确保,放后台线程避免主线程下载
+            if (!applyPending.compareAndSet(false, true)) return
+            Thread {
+                try {
+                    ensureLoadEquipApplied(env, config, target)
+                } catch (error: Throwable) {
+                    env.log("Custom skin load equip ensure failed", error)
+                } finally {
+                    applyPending.set(false)
+                }
+            }.apply { name = "BBZQ-CustomSkinLoadEquip" }.start()
+            return
+        }
         if (!applyPending.compareAndSet(false, true)) return
         Thread {
             try {
@@ -69,7 +82,7 @@ internal object CustomSkinApplier {
             }
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            // API 33+ 注册非系统广播必须显式声明导出标志
+            // Android 13+ 注册非系统广播必须显式声明导出标志
             env.hostContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
             env.hostContext.registerReceiver(receiver, filter)
@@ -113,6 +126,13 @@ internal object CustomSkinApplier {
         }
     }
 
+    // 幂等确保:文件已在则跳过下载,总是广播让 web 进程重读
+    private fun ensureLoadEquipApplied(env: RoamingEnv, raw: String, target: SkinTarget) {
+        if (!ModuleSettings.isCustomSkinEnabled(env.prefs)) return
+        val root = runCatching { JSONObject(raw) }.getOrNull() ?: return
+        applyLoadEquip(env, root, target.garbDir)
+    }
+
     private fun apply(env: RoamingEnv, raw: String, target: SkinTarget) {
         val root = JSONObject(raw)
         val skin = root.optJSONObject("user_equip") ?: root
@@ -125,8 +145,28 @@ internal object CustomSkinApplier {
         URL(packageUrl).openStream().use { input -> archive.outputStream().use(input::copyTo) }
         unzipSafely(archive, target.assetsDir)
 
+        applyLoadEquip(env, root, target.garbDir)
         writeTarget(env, target)
         env.log("Custom skin applied: id=${target.id} version=${target.version}")
+    }
+
+    // 下拉动画:loading_url 下载到 garb/load_equip/<base64(url)> 供 web 进程加载,再广播重读
+    private fun applyLoadEquip(env: RoamingEnv, root: JSONObject, garbDir: File) {
+        val loadEquip = root.optJSONObject("load_equip") ?: return
+        val url = loadEquip.optString("loading_url")
+        if (url.isBlank()) return
+        runCatching {
+            val dir = File(garbDir, "load_equip").also { it.mkdirs() }
+            val fileName = android.util.Base64.encodeToString(url.toByteArray(), android.util.Base64.NO_WRAP)
+            val target = File(dir, fileName)
+            if (!target.isFile || target.length() == 0L) {
+                URL(url).openStream().use { input -> target.outputStream().use(input::copyTo) }
+            }
+            env.hostContext.sendBroadcast(Intent("${env.packageName}.garb.LOAD_EQUIP_CHANGE"))
+            env.log("Custom skin load equip applied: $fileName")
+        }.onFailure {
+            env.log("Custom skin load equip failed", it)
+        }
     }
 
     private fun notifyGarbChanged(env: RoamingEnv, garb: String) {

--- a/app/src/main/java/io/github/bbzq/feats/hook/CustomSkinApplier.kt
+++ b/app/src/main/java/io/github/bbzq/feats/hook/CustomSkinApplier.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.Color
+import android.os.Build
 import io.github.bbzq.ModuleSettings
 import io.github.bbzq.feats.HostAccountResolver
 import io.github.bbzq.feats.RoamingEnv
@@ -55,7 +56,7 @@ internal object CustomSkinApplier {
         if (!receiverRegistered.compareAndSet(false, true)) return
         val action = "${env.packageName}.garb.GARB_CHANGE"
         val filter = IntentFilter(action).apply { priority = -1000 }
-        env.hostContext.registerReceiver(object : BroadcastReceiver() {
+        val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
                 if (intent.getIntExtra("key_broadcast_data_type", 0) != 1) return
                 if (intent.getBooleanExtra(EXTRA_SELF_APPLIED, false)) return
@@ -66,7 +67,13 @@ internal object CustomSkinApplier {
                 if (customId <= 0L || incomingId == customId) return
                 scheduleReapply(env)
             }
-        }, filter)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // API 33+ 注册非系统广播必须显式声明导出标志
+            env.hostContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            env.hostContext.registerReceiver(receiver, filter)
+        }
         env.log("Custom skin observer registered for $action")
     }
 

--- a/app/src/main/java/io/github/bbzq/feats/hook/CustomThemeHook.kt
+++ b/app/src/main/java/io/github/bbzq/feats/hook/CustomThemeHook.kt
@@ -1,6 +1,7 @@
 package io.github.bbzq.feats.hook
 
 import android.app.AlertDialog
+import android.content.Intent
 import android.graphics.Color
 import android.util.SparseArray
 import android.view.View
@@ -12,11 +13,13 @@ import io.github.bbzq.feats.allFields
 import io.github.bbzq.feats.allMethods
 import io.github.bbzq.feats.fieldOrNull
 import io.github.bbzq.feats.hookBefore
+import io.github.bbzq.feats.hookAfter
 import io.github.bbzq.feats.newInstanceOrNull
 import io.github.bbzq.feats.replace
 import io.github.bbzq.feats.setBooleanField
 import io.github.bbzq.feats.setIntField
 import io.github.bbzq.feats.setObjectField
+import io.github.bbzq.feats.symbol.RestoredCustomSkinSymbols
 import io.github.bbzq.feats.symbol.RestoredCustomThemeSymbols
 import org.json.JSONObject
 import java.lang.reflect.Constructor
@@ -28,6 +31,10 @@ import java.lang.reflect.Modifier
  * BiliRoaming while keeping all settings in BBZQ's remote preferences.
  */
 class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
+    // play_icon 配置缓存:raw 指纹变化(皮肤切换)时重解析
+    private var cachedSkinRaw: String? = null
+    private var cachedPlayIconConfig: JSONObject? = null
+
     override fun startHook() {
         val customSkinEnabled = ModuleSettings.isCustomSkinEnabled(prefs)
         // A portable garb contains its own colors. It must win over this module's
@@ -35,23 +42,21 @@ class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
         val customColorEnabled = ModuleSettings.isCustomThemeEnabled(prefs) && !customSkinEnabled
         if (customSkinEnabled) {
             CustomSkinApplier.applyIfChanged(env)
-            val resolver = env.symbols?.customSkin?.restore(classLoader)
-            if (resolver == null) {
+            val skinSymbols = env.symbols?.customSkin?.restore(classLoader)
+            if (skinSymbols == null) {
                 log("Custom skin resolver missing; using broadcast fallback")
             } else {
-                hookSkinResolver(resolver)
+                hookSkinResolver(skinSymbols.resolverMethod)
+                // 皮肤响应/进度条图标/下拉动画注入(customSkin 符号独立于 customTheme)
+                hookSkinResponse(skinSymbols)
+                hookPlayIcon(skinSymbols)
+                applyLoadEquipConf(skinSymbols)
+                hookBlkvGet(skinSymbols)
             }
-            // Replace the parsed skin response so every official /x/resource/show/skin
-            // refresh keeps the imported equip instead of reverting to the server garb.
             // Suppressing the reset also stops an already-equipped theme from overriding
             // the imported skin when MainActivity restores it on startup.
-            val skinSymbols = env.symbols?.customTheme?.restore(classLoader)
-            if (skinSymbols == null) {
-                log("Custom skin response hook skipped: theme symbols missing")
-            } else {
-                hookSkinResponse(skinSymbols)
-                suppressThemeReset(skinSymbols)
-            }
+            val themeSymbols = env.symbols?.customTheme?.restore(classLoader)
+            if (themeSymbols != null) suppressThemeReset(themeSymbols)
         }
         if (!customColorEnabled) {
             log("startHook: customSkin=$customSkinEnabled customColor=$customColorEnabled")
@@ -106,9 +111,9 @@ class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
      * Substitute the skin model while Bilibili parses /x/resource/show/skin.
      * Thus every official refresh receives the imported equip before it can update UI/state.
      */
-    private fun hookSkinResponse(symbols: RestoredCustomThemeSymbols) {
-        val userGarbSetter = symbols.skinResponseUserGarbSetter ?: run {
-            if (symbols.skinResolveMethod == null) log("Custom skin hooks unavailable; using broadcast fallback")
+    private fun hookSkinResponse(skinSymbols: RestoredCustomSkinSymbols) {
+        val userGarbSetter = skinSymbols.skinResponseUserGarbSetter ?: run {
+            log("Custom skin response hooks skipped: skin response class missing")
             return
         }
         env.hookBefore(userGarbSetter) { param ->
@@ -117,7 +122,7 @@ class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
             val replacement = parseHostJson(skin.toString(), userGarbSetter.parameterTypes[0]) ?: return@hookBefore
             param.args[0] = replacement
         }
-        symbols.skinResponseLoadEquipSetter?.let { loadEquipSetter ->
+        skinSymbols.skinResponseLoadEquipSetter?.let { loadEquipSetter ->
             env.hookBefore(loadEquipSetter) { param ->
                 if (!ModuleSettings.isCustomSkinEnabled(prefs)) return@hookBefore
                 val loadEquip = customSkinConfig()?.optJSONObject("load_equip") ?: return@hookBefore
@@ -126,6 +131,127 @@ class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
             }
         }
         log("Custom skin response hook installed: ${userGarbSetter.declaringClass.name}")
+    }
+
+    // 进度条图标(play_icon)注入:直接替换 PlayerIcon 模型三个 URL getter 的返回值
+    private fun hookPlayIcon(skinSymbols: RestoredCustomSkinSymbols) {
+        if (skinSymbols.videoPlayerIconGetters.isEmpty()) {
+            log("Custom skin play icon hook skipped: playerIcon getters missing")
+            return
+        }
+        skinSymbols.videoPlayerIconGetters.forEach { getter ->
+            env.hookAfter(getter) { param ->
+                if (!ModuleSettings.isCustomSkinEnabled(prefs)) return@hookAfter
+                val playIcon = playIconConfig() ?: return@hookAfter
+                val url = when (getter.name) {
+                    "getDragLeftPng" -> playIcon.optString("drag_left_png")
+                    "getDragRightPng" -> playIcon.optString("drag_right_png")
+                    "getMiddlePng" -> playIcon.optString("middle_png")
+                    else -> return@hookAfter
+                }
+                if (url.isNotBlank()) param.result = url
+            }
+            log("Custom skin play icon hook installed: ${getter.declaringClass.name}.${getter.name}")
+        }
+    }
+
+    /** play_icon 配置:按 raw 指纹缓存,皮肤切换时自动重解析 */
+    private fun playIconConfig(): JSONObject? {
+        val raw = ModuleSettings.getCustomSkinJson(prefs)
+        if (raw.isBlank()) return null
+        if (cachedSkinRaw != raw) {
+            cachedSkinRaw = raw
+            cachedPlayIconConfig = runCatching { JSONObject(raw).optJSONObject("play_icon") }.getOrNull()
+        }
+        return cachedPlayIconConfig
+    }
+
+    // 下拉动画配置写入 blkv(web 进程读它才知道动画文件名),再广播让其重读
+    private fun applyLoadEquipConf(skinSymbols: RestoredCustomSkinSymbols) {
+        val factory = skinSymbols.blkvPrefsFactory ?: run {
+            log("Custom skin load equip conf skipped: blkv factory missing")
+            return
+        }
+        val root = customSkinConfig() ?: return
+        val loadEquip = root.optJSONObject("load_equip") ?: run {
+            log("Custom skin load equip conf skipped: no load_equip")
+            return
+        }
+        if (loadEquip.optString("loading_url").isBlank() || loadEquip.optLong("id") <= 0L) {
+            log("Custom skin load equip conf skipped: load_equip incomplete")
+            return
+        }
+        runCatching {
+            // 工厂是静态方法,传 null 接收者
+            val prefs = factory.invoke(null, env.hostContext, LOAD_EQUIP_CONF_PREFS_FILE, false, 0) ?: return@runCatching
+            if (!writeBlkv(prefs, LOAD_EQUIP_CONF_KEY, loadEquip.toString())) {
+                log("Custom skin load equip conf write failed: no putString api on ${prefs.javaClass.name}")
+                return@runCatching
+            }
+            // 先写再广播,web 进程收到广播后重读才能拿到新配置
+            env.hostContext.sendBroadcast(Intent("${env.packageName}.garb.LOAD_EQUIP_CHANGE"))
+            log("Custom skin load equip conf written: id=${loadEquip.optLong("id")} via ${factory.declaringClass.name}.${factory.name}")
+        }.onFailure {
+            log("Custom skin load equip conf write failed", it)
+        }
+    }
+
+    // 反射写 blkv:优先标准 SharedPreferences 路径,失败逐级降级适配 B 站 SharedPrefX
+    private fun writeBlkv(prefs: Any, key: String, value: String): Boolean {
+        runCatching {
+            val editor = prefs.javaClass.getMethod("edit").invoke(prefs) ?: return@runCatching
+            editor.javaClass.getMethod("putString", String::class.java, String::class.java)
+                .invoke(editor, key, value)
+            commitIfPresent(editor)
+            return true
+        }
+        runCatching {
+            prefs.javaClass.getMethod("putString", String::class.java, String::class.java)
+                .invoke(prefs, key, value)
+            commitIfPresent(prefs)
+            return true
+        }
+        runCatching {
+            val editMethod = prefs.javaClass.methods.firstOrNull { m ->
+                m.parameterCount == 0 && m.returnType.name.contains("Editor")
+            } ?: return@runCatching
+            val editor = editMethod.invoke(prefs) ?: return@runCatching
+            val put = editor.javaClass.methods.firstOrNull { m ->
+                m.name == "putString" && m.parameterCount == 2
+            } ?: return@runCatching
+            put.invoke(editor, key, value)
+            commitIfPresent(editor)
+            return true
+        }
+        return false
+    }
+
+    private fun commitIfPresent(editor: Any) {
+        runCatching { editor.javaClass.getMethod("apply").invoke(editor) }
+            .getOrElse { runCatching { editor.javaClass.getMethod("commit").invoke(editor) } }
+    }
+
+    // 读取边界拦截:所有 blkv 读取经过 SharedPrefX.get,读下拉配置时强制返回自制 JSON,
+    // 摆脱广播时序/跨进程缓存导致的时好时坏
+    private fun hookBlkvGet(skinSymbols: RestoredCustomSkinSymbols) {
+        if (skinSymbols.blkvGetMethods.isEmpty()) {
+            log("Custom skin blkv get hook skipped: SharedPrefX get methods missing")
+            return
+        }
+        skinSymbols.blkvGetMethods.forEach { getter ->
+            env.hookAfter(getter) { param ->
+                if (!ModuleSettings.isCustomSkinEnabled(prefs)) return@hookAfter
+                if (param.args.getOrNull(0) != LOAD_EQUIP_CONF_KEY) return@hookAfter
+                val root = customSkinConfig() ?: return@hookAfter
+                val loadEquip = root.optJSONObject("load_equip") ?: return@hookAfter
+                if (loadEquip.optString("loading_url").isBlank() || loadEquip.optLong("id") <= 0L) {
+                    return@hookAfter
+                }
+                param.result = loadEquip.toString()
+                log("Custom skin blkv get injected: ${getter.declaringClass.name}.${getter.name}")
+            }
+            log("Custom skin blkv get hook installed: ${getter.declaringClass.name}.${getter.name}")
+        }
     }
 
     private fun customSkinConfig(): JSONObject? = runCatching {
@@ -169,6 +295,14 @@ class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
             }
         }
         log("CustomTheme web colors installed: ${formatColor(color)}")
+    }
+
+    // 下拉动画由 web 进程渲染,该进程不跑完整皮肤流程,单独补写配置并装读取拦截
+    fun insertLoadEquipForWebProcess() {
+        if (!ModuleSettings.isCustomSkinEnabled(prefs)) return
+        val skinSymbols = env.symbols?.customSkin?.restore(classLoader) ?: return
+        applyLoadEquipConf(skinSymbols)
+        hookBlkvGet(skinSymbols)
     }
 
     private fun installThemeMaps(symbols: RestoredCustomThemeSymbols, primaryColor: Int) {
@@ -310,6 +444,9 @@ class CustomThemeHook(env: RoamingEnv) : BaseRoamingHook(env) {
         private const val CUSTOM_THEME_ID1 = 114514
         private const val CUSTOM_THEME_ID2 = 1919810
         private const val MAIN_ACTIVITY = "tv.danmaku.bili.MainActivityV2"
+        // B 站 blkv 存储下拉刷新动画配置的 key,以及存储该配置的 blkv 文件名
+        private const val LOAD_EQUIP_CONF_KEY = "garb_load_equip_conf"
+        private const val LOAD_EQUIP_CONF_PREFS_FILE = "instance.bili_preference"
 
         private fun generateColorArray(primaryColor: Int): IntArray {
             val colors = IntArray(4)

--- a/app/src/main/java/io/github/bbzq/feats/hook/LiveRoomBlurMaskHook.kt
+++ b/app/src/main/java/io/github/bbzq/feats/hook/LiveRoomBlurMaskHook.kt
@@ -1,0 +1,80 @@
+package io.github.bbzq.feats.hook
+
+import io.github.bbzq.ModuleSettings
+import io.github.bbzq.ModuleSettingsBridge
+import io.github.bbzq.feats.BaseRoamingHook
+import io.github.bbzq.feats.RoamingEnv
+import io.github.bbzq.feats.hookAfter
+import io.github.bbzq.feats.setObjectField
+import java.lang.reflect.Type
+
+class LiveRoomBlurMaskHook(env: RoamingEnv) : BaseRoamingHook(env) {
+    override fun startHook() {
+        if (!ModuleSettings.isRemoveLiveRoomBlurMaskEnabled(prefs)) {
+            log("startHook: LiveRoomBlurMask disabled, settings=${ModuleSettingsBridge.lastStatus}")
+            return
+        }
+
+        val jsonClass = runCatching { classLoader.loadClass("com.alibaba.fastjson.JSON") }.getOrNull()
+        if (jsonClass == null) {
+            log("startHook: Fastjson JSON class not found")
+            return
+        }
+
+        val roomInfoClassName = "com.bilibili.bililive.videoliveplayer.net.beans.gateway.roominfo.BiliLiveRoomInfo"
+        var hookCount = 0
+
+        // Intercept parseObject(String text, Type clazz, Feature... features)
+        jsonClass.methods.firstOrNull { 
+            it.name == "parseObject" && 
+            it.parameterTypes.size == 3 && 
+            it.parameterTypes[0] == String::class.java &&
+            it.parameterTypes[1] == Type::class.java &&
+            it.parameterTypes[2].isArray && it.parameterTypes[2].componentType.name.endsWith("Feature")
+        }?.let { method ->
+            env.hookAfter(method) { param ->
+                checkAndPurifyResult(param.result, roomInfoClassName)
+            }
+            hookCount++
+        }
+
+        // Intercept parseObject(String text, Type clazz, ParserConfig config, ParseProcess process, int features, Feature... features)
+        jsonClass.methods.firstOrNull { 
+            it.name == "parseObject" && 
+            it.parameterTypes.size == 6 && 
+            it.parameterTypes[0] == String::class.java &&
+            it.parameterTypes[1] == Type::class.java
+        }?.let { method ->
+            env.hookAfter(method) { param ->
+                checkAndPurifyResult(param.result, roomInfoClassName)
+            }
+            hookCount++
+        }
+
+        log("startHook: LiveRoomBlurMask hooked $hookCount Fastjson methods")
+    }
+
+    private fun checkAndPurifyResult(result: Any?, roomInfoClassName: String) {
+        if (result == null) return
+        
+        // Is it the BiliLiveRoomInfo object directly?
+        if (result.javaClass.name == roomInfoClassName) {
+            purifyAreaMask(result)
+            return
+        }
+        
+        // Is it wrapped in GeneralResponse?
+        if (result.javaClass.name == "com.bilibili.okretro.GeneralResponse") {
+            val data = runCatching { result.javaClass.getField("data").get(result) }.getOrNull()
+            if (data != null && data.javaClass.name == roomInfoClassName) {
+                purifyAreaMask(data)
+            }
+        }
+    }
+
+    private fun purifyAreaMask(roomInfo: Any) {
+        if (roomInfo.setObjectField("areaMaskInfo", null)) {
+            log("LiveRoomBlurMask: removed areaMaskInfo from BiliLiveRoomInfo")
+        }
+    }
+}

--- a/app/src/main/java/io/github/bbzq/feats/symbol/BiliHookSymbols.kt
+++ b/app/src/main/java/io/github/bbzq/feats/symbol/BiliHookSymbols.kt
@@ -147,7 +147,7 @@ data class BiliHookSymbols(
 }
 
 object DexKitRuleVersions {
-    const val CURRENT = 58
+    const val CURRENT = 59
 }
 
 data class HookPointStatus(
@@ -2001,21 +2001,83 @@ data class RestoredTripleSpeedSymbols(
 
 data class CustomSkinSymbols(
     val resolverMethod: MethodDescriptor,
+    // 皮肤响应注入(setUserGarb/setLoadEquip)与解析入口,缺失时降级为广播方案
+    val skinResponseClassName: String? = null,
+    val skinResponseUserGarbSetter: MethodDescriptor? = null,
+    val skinResponseLoadEquipSetter: MethodDescriptor? = null,
+    val skinResolveMethod: MethodDescriptor? = null,
+    // 进度条图标(play_icon)三个 URL getter:左拉/右拉/不拉表现图
+    val videoPlayerIconGetters: List<MethodDescriptor> = emptyList(),
+    // blkv 工厂(写下拉动画配置)与其读取出口 get(String,Object)(读取拦截)
+    val blkvPrefsFactory: MethodDescriptor? = null,
+    val blkvGetMethods: List<MethodDescriptor> = emptyList(),
     val evidence: String,
 ) {
     fun toJson(): JSONObject = JSONObject()
         .put("resolverMethod", resolverMethod.toJson())
+        .putOpt("skinResponseClassName", skinResponseClassName)
+        .putOpt("skinResponseUserGarbSetter", skinResponseUserGarbSetter?.toJson())
+        .putOpt("skinResponseLoadEquipSetter", skinResponseLoadEquipSetter?.toJson())
+        .putOpt("skinResolveMethod", skinResolveMethod?.toJson())
+        .put("videoPlayerIconGetters", org.json.JSONArray(videoPlayerIconGetters.map { it.toJson() }))
+        .putOpt("blkvPrefsFactory", blkvPrefsFactory?.toJson())
+        .put("blkvGetMethods", org.json.JSONArray(blkvGetMethods.map { it.toJson() }))
         .put("evidence", evidence)
 
-    fun restore(classLoader: ClassLoader): Method? = resolverMethod.restoreOptional(classLoader)
+    fun restore(classLoader: ClassLoader): RestoredCustomSkinSymbols? {
+        val resolver = resolverMethod.restoreOptional(classLoader) ?: return null
+        val skinResponseClass = skinResponseClassName?.let(classLoader::loadClassOrNull)
+        val userGarbSetter = skinResponseUserGarbSetter?.restoreOptional(classLoader)
+        val loadEquipSetter = skinResponseLoadEquipSetter?.restoreOptional(classLoader)
+        val skinResolveMethod = skinResolveMethod?.restoreOptional(classLoader)
+        val videoPlayerIconGetters = videoPlayerIconGetters.mapNotNull { it.restoreOptional(classLoader) }
+        val blkvPrefsFactory = blkvPrefsFactory?.restoreOptional(classLoader)
+        val blkvGetMethods = blkvGetMethods.mapNotNull { it.restoreOptional(classLoader) }
+        return RestoredCustomSkinSymbols(
+            resolverMethod = resolver,
+            skinResponseClass = skinResponseClass,
+            skinResponseUserGarbSetter = userGarbSetter,
+            skinResponseLoadEquipSetter = loadEquipSetter,
+            skinResolveMethod = skinResolveMethod,
+            videoPlayerIconGetters = videoPlayerIconGetters,
+            blkvPrefsFactory = blkvPrefsFactory,
+            blkvGetMethods = blkvGetMethods,
+        )
+    }
 
     companion object {
         fun fromJson(obj: JSONObject): CustomSkinSymbols = CustomSkinSymbols(
             resolverMethod = MethodDescriptor.fromJson(obj.getJSONObject("resolverMethod")),
+            skinResponseClassName = obj.optString("skinResponseClassName").takeIf { it.isNotBlank() },
+            skinResponseUserGarbSetter = obj.optJSONObject("skinResponseUserGarbSetter")?.let(MethodDescriptor::fromJson),
+            skinResponseLoadEquipSetter = obj.optJSONObject("skinResponseLoadEquipSetter")?.let(MethodDescriptor::fromJson),
+            skinResolveMethod = obj.optJSONObject("skinResolveMethod")?.let(MethodDescriptor::fromJson),
+            videoPlayerIconGetters = obj.optJSONArray("videoPlayerIconGetters")?.let { arr ->
+                (0 until arr.length()).mapNotNull { i ->
+                    arr.optJSONObject(i)?.let(MethodDescriptor::fromJson)
+                }
+            } ?: emptyList(),
+            blkvPrefsFactory = obj.optJSONObject("blkvPrefsFactory")?.let(MethodDescriptor::fromJson),
+            blkvGetMethods = obj.optJSONArray("blkvGetMethods")?.let { arr ->
+                (0 until arr.length()).mapNotNull { i ->
+                    arr.optJSONObject(i)?.let(MethodDescriptor::fromJson)
+                }
+            } ?: emptyList(),
             evidence = obj.optString("evidence", "-"),
         )
     }
 }
+
+data class RestoredCustomSkinSymbols(
+    val resolverMethod: Method,
+    val skinResponseClass: Class<*>?,
+    val skinResponseUserGarbSetter: Method?,
+    val skinResponseLoadEquipSetter: Method?,
+    val skinResolveMethod: Method?,
+    val videoPlayerIconGetters: List<Method>,
+    val blkvPrefsFactory: Method?,
+    val blkvGetMethods: List<Method>,
+)
 
 data class CustomThemeSymbols(
     val themeHelperClassName: String,

--- a/app/src/main/java/io/github/bbzq/feats/symbol/BiliSymbolResolver.kt
+++ b/app/src/main/java/io/github/bbzq/feats/symbol/BiliSymbolResolver.kt
@@ -1004,9 +1004,99 @@ object BiliSymbolResolver {
                 }
         }.getOrNull() ?: return SymbolScanResult.Missing("garb resolver method not found")
         resolverMethod.isAccessible = true
+
+        // 皮肤响应模型:含 setUserGarb / setLoadEquip setter,
+        // load_equip(下拉动画)与 user_equip 一起在解析 /x/resource/show/skin 时注入
+        val skinResponseClass = runCatching {
+            currentBridge.findClass(
+                FindClass.create().matcher(ClassMatcher.create().usingStrings("user_equip")),
+            ).mapNotNull { classLoader.loadClassOrNull(it.name) }
+                .firstOrNull { type ->
+                    type.declaredMethods.any { it.name == "setUserGarb" && it.parameterCount == 1 }
+                }
+        }.getOrNull()
+        val skinResponseUserGarbSetter = skinResponseClass?.declaredMethods?.firstOrNull {
+            it.name == "setUserGarb" && it.parameterCount == 1
+        }?.apply { isAccessible = true }
+        val skinResponseLoadEquipSetter = skinResponseClass?.declaredMethods?.firstOrNull {
+            it.name == "setLoadEquip" && it.parameterCount == 1
+        }?.apply { isAccessible = true }
+
+        // 皮肤解析入口方法(宽松匹配,与 scanCustomTheme 的规则一致)
+        val skinResolveMethod = runCatching {
+            currentBridge.findMethod(
+                FindMethod.create().matcher(MethodMatcher.create().usingStrings("shouldApplyForceOpGarb =")),
+            ).mapNotNull { runCatching { it.getMethodInstance(classLoader) }.getOrNull() }
+                .firstOrNull { it.parameterCount == 1 && it.returnType != Void.TYPE }
+                ?.apply { isAccessible = true }
+        }.getOrNull()
+
+        // 进度条图标(play_icon)的三个 URL getter:类名限定 PlayerIcon,
+        // 命中 protobuf PlayerIcon 与番剧 JSON 模型,排除 Description 等无关类
+        val videoPlayerIconGetters = runCatching {
+            listOf("getDragLeftPng", "getDragRightPng", "getMiddlePng").flatMap { methodName ->
+                currentBridge.findMethod(
+                    FindMethod.create().matcher(MethodMatcher.create().name(methodName)),
+                ).mapNotNull { runCatching { it.getMethodInstance(classLoader) }.getOrNull() }
+                    .filter { method ->
+                        method.parameterCount == 0 &&
+                            !Modifier.isAbstract(method.modifiers) &&
+                            !method.declaringClass.isInterface &&
+                            method.declaringClass.name.contains("PlayerIcon")
+                    }
+            }.distinctBy { "${it.declaringClass.name}.${it.name}" }
+                .map { it.apply { isAccessible = true } }
+        }.getOrDefault(emptyList())
+
+        // blkv 工厂(返回 SharedPrefX,非标准 SharedPreferences):反射调用写入下拉动画配置
+        val blkvPrefsFactory = runCatching {
+            currentBridge.findMethod(
+                FindMethod.create().matcher(MethodMatcher.create().usingStrings(".blkv")),
+            ).mapNotNull { runCatching { it.getMethodInstance(classLoader) }.getOrNull() }
+                .firstOrNull { method ->
+                    method.parameterCount == 4 &&
+                        Context::class.java.isAssignableFrom(method.parameterTypes[0]) &&
+                        method.parameterTypes[1] == String::class.java &&
+                        method.parameterTypes[2] == Boolean::class.javaPrimitiveType &&
+                        method.parameterTypes[3] == Int::class.javaPrimitiveType &&
+                        method.returnType.name.contains("Shared")
+                }
+                ?.apply { isAccessible = true }
+        }.getOrNull()
+
+        // SharedPrefX 实现类的 get(String,Object):所有 blkv 读取的出口,
+        // hook 后读 garb_load_equip_conf 强制返回自制配置,摆脱广播/缓存竞态
+        val blkvGetMethods = runCatching {
+            currentBridge.findClass(
+                FindClass.create().matcher(ClassMatcher.create().addInterface("com.bilibili.lib.blkv.SharedPrefX")),
+            ).mapNotNull { runCatching { classLoader.loadClassOrNull(it.name) }.getOrNull() }
+                .flatMap { clazz ->
+                    clazz.declaredMethods.asSequence()
+                        .filter { method ->
+                            method.name == "get" && method.parameterCount == 2 &&
+                                method.parameterTypes[0] == String::class.java &&
+                                !method.parameterTypes[1].isPrimitive
+                        }
+                        .map { it.apply { isAccessible = true } }
+                        .toList()
+                }.distinctBy { "${it.declaringClass.name}.${it.name}" }
+        }.getOrDefault(emptyList())
+
         val symbols = CustomSkinSymbols(
             resolverMethod = MethodDescriptor.of(resolverMethod),
-            evidence = "resolver=${resolverMethod.declaringClass.name}.${resolverMethod.name}",
+            skinResponseClassName = skinResponseClass?.name,
+            skinResponseUserGarbSetter = skinResponseUserGarbSetter?.let(MethodDescriptor::of),
+            skinResponseLoadEquipSetter = skinResponseLoadEquipSetter?.let(MethodDescriptor::of),
+            skinResolveMethod = skinResolveMethod?.let(MethodDescriptor::of),
+            videoPlayerIconGetters = videoPlayerIconGetters.map(MethodDescriptor::of),
+            blkvPrefsFactory = blkvPrefsFactory?.let(MethodDescriptor::of),
+            blkvGetMethods = blkvGetMethods.map(MethodDescriptor::of),
+            evidence = "resolver=${resolverMethod.declaringClass.name}.${resolverMethod.name}" +
+                ",userGarb=${skinResponseUserGarbSetter != null}" +
+                ",loadEquip=${skinResponseLoadEquipSetter != null}" +
+                ",videoPlayerIcon=${videoPlayerIconGetters.size}" +
+                ",blkvFactory=${blkvPrefsFactory != null}" +
+                ",blkvGets=${blkvGetMethods.size}",
         )
         return SymbolScanResult.Found(symbols, resolverMethod.declaringClass.name, symbols.evidence)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
     <string name="block_live_reservation_summary">移除视频详情页内的直播预约悬浮卡片。</string>
     <string name="block_live_room_qoe_popup_title">屏蔽直播间效果弹窗</string>
     <string name="block_live_room_qoe_popup_summary">移除直播间内的体验调研或效果打分弹窗。</string>
+    <string name="remove_live_room_blur_mask_title">移除直播间模糊遮罩</string>
+    <string name="remove_live_room_blur_mask_summary">移除部分分区（如我的世界、吃鸡行动）直播间在客户端本地生成的画面遮罩。</string>
     <string name="disable_long_press_copy_title">去除长按复制</string>
     <string name="disable_long_press_copy_summary">禁用评论、动态及简介的长按直接复制行为，防止误触。</string>
     <string name="enhance_long_press_copy_title">长按自由复制</string>


### PR DESCRIPTION
## 描述

先修复自制主题(导入自制主题)在 Bilibili 9.0.0+ 上失效的问题，再在此基础上支持进度条图片与下拉刷新动画的替换，实现参考 BiliRoamingX。

### 自制主题配置文件

B 站主题配置文件，形如 `xxx.json`  `xxx_trans.json` ，内容大致如下:

```jsonc
{
  "user_equip": {
    "id": 12345678,                // 皮肤 ID
    "name": "示例皮肤",             // 皮肤名称
    "ver": 12345678,                      // 版本号
    "package_url": "https://example.com/skin.zip",   // 主题资源包的下载地址(zip)
    "data": {
      "color": "example",         
      "tail_icon_mode": "color",   
      "head_myself_mp4_play": "loop"  
    }
  },
  // 下面两项仅 _trans结尾的 json 文件有
  "load_equip": {
    "id": 12345678,                
    "loading_url": "https://example.com/loading.webp"   // 下拉刷新动画图片
  },

  "play_icon": {
    "drag_left_png": "https://example.com/drag_left.png",    // 进度条按钮左拉状态图片
    "drag_right_png": "https://example.com/drag_right.png",  // 进度条按钮右拉状态图片
    "middle_png": "https://example.com/middle.png"           // 进度条按钮默认状态图片
  }
}
```

原逻辑不支持对下拉刷新动画与进度条按钮图片的替换。

### 实现方式

#### 1. 自制主题广播注册修复(适配 API 33+)
* **背景与根因**:自制主题依赖监听宿主内部广播 `garb.GARB_CHANGE` 来触发资源热重载。在宿主 `targetSdk >= 33`(如 9.10.0+)环境下，动态注册接收器缺少导出标志会导致系统抛出 `SecurityException`，注册直接失败，使主题功能整体失效。
* **实现**:该广播仅用于应用内进程通信，针对 API 33+ 设备注册时显式传入 `Context.RECEIVER_NOT_EXPORTED` 标志，既满足系统合规要求，又避免暴露接收端口。

#### 2. play_icon(进度条按钮样式替换)
* **实现**:播放器 UI 通过 `PlayerIcon` 实体类的 `getDragLeftPng`、`getDragRightPng`、`getMiddlePng` 读取各状态表现图。Hook 上述三个 Getter，命中时直接将返回值重定向至配置文件里的自定义图片地址。
* **健壮性优化**:扫描阶段以类名限定 `PlayerIcon`，避免全 Dex 方法名扫描因同名 Getter 误伤其他模块。

#### 3. load_equip(下拉刷新动画替换)
* **主动写入与通知**:反射调用宿主 BLKV 存储实例，将配置写入 `garb_load_equip_conf`，并发送 `LOAD_EQUIP_CHANGE` 广播触发 Web 进程重新加载动画。
* **双重保障(防时序竞争)**:针对跨进程缓存延迟与广播时序导致的偶发失效，补充 Hook 存储读取层 `SharedPrefX.get`。当请求目标 Key 时强制返回目标配置，确保各进程在任意时刻读取均具备一致性。


### 其他 

+ 在 9.10.0 上做了测试
+ Vibe Coding