### PR TITLE
feat: 添加支持通过 Shizuku/Sui 强制停止并重启哔哩哔哩

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,4 +161,6 @@ dependencies {
     implementation(libs.libxposed.service)
     implementation(libs.dexkit)
     implementation(libs.okhttp)
+    implementation(libs.shizuku.api)
+    implementation(libs.shizuku.provider)
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -65,3 +65,11 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+
+# 7. Shizuku / Sui 库（ShizukuProvider 由 manifest 引用，须保留）
+-keep class rikka.shizuku.** { *; }
+-keep class rikka.sui.** { *; }
+-keep class moe.shizuku.** { *; }
+-dontwarn rikka.shizuku.**
+-dontwarn rikka.sui.**
+-dontwarn moe.shizuku.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,9 +6,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
-    <uses-permission
-        android:name="moe.shizuku.manager.permission.API_V23"
-        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="moe.shizuku.manager.permission.API_V23" />
 
     <queries>
         <package android:name="tv.danmaku.bili" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <uses-permission
+        android:name="moe.shizuku.manager.permission.API_V23"
+        tools:ignore="ScopedStorage" />
 
     <queries>
         <package android:name="tv.danmaku.bili" />
@@ -13,6 +16,8 @@
         <package android:name="org.readera" />
         <package android:name="top.nkbe.npatch" />
         <provider android:authorities="top.nkbe.npatch.remote" />
+        <package android:name="moe.shizuku.manager" />
+        <package android:name="moe.shizuku.privileged.api" />
     </queries>
 
     <application
@@ -54,6 +59,16 @@
                 <category android:name="android.intent.category.INFO" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:multiprocess="false"
+            android:enabled="true"
+            android:exported="true"
+            android:writePermission="android.permission.DUMP"
+            tools:targetApi="31"
+            tools:ignore="ExportedContentProvider" />
 
     </application>
 

--- a/app/src/main/java/io/github/bbzq/RootUtils.kt
+++ b/app/src/main/java/io/github/bbzq/RootUtils.kt
@@ -12,8 +12,12 @@ import android.os.Looper
 import android.widget.Toast
 import java.io.File
 import java.util.concurrent.Executors
+import rikka.shizuku.Shizuku
+import rikka.sui.Sui
 
 object RootUtils {
+    private const val SHIZUKU_REQUEST_CODE = 0xBB29
+
     private val executor = Executors.newSingleThreadExecutor()
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -51,10 +55,8 @@ object RootUtils {
 
     fun resolveBilibiliPackage(context: Context, prefs: SharedPreferences?): String {
         val runtimePkg = prefs?.getString(ModuleSettings.KEY_RUNTIME_HOST_PACKAGE, null)
-        if (!runtimePkg.isNullOrBlank()) {
-            if (isPackageInstalled(context.packageManager, runtimePkg)) {
-                return runtimePkg
-            }
+        if (!runtimePkg.isNullOrBlank() && isPackageInstalled(context.packageManager, runtimePkg)) {
+            return runtimePkg
         }
         for (pkg in CANDIDATE_PACKAGES) {
             if (isPackageInstalled(context.packageManager, pkg)) {
@@ -62,6 +64,54 @@ object RootUtils {
             }
         }
         return runtimePkg?.takeIf { it.isNotBlank() } ?: "tv.danmaku.bili"
+    }
+
+    /**
+     * 调用 Shizuku/Sui API 前确保当前进程 Sui 桥接已建立。
+     * 强制停止逻辑运行在 BBZQ 自身进程（目标是 tv.danmaku.bili），
+     * ShizukuProvider 通常会自动 init；此处用 [Sui.isSui] 守卫做一次安全兜底。
+     */
+    private fun ensureSuiInitialized(context: Context): Boolean {
+        if (Sui.isSui()) return true
+        return runCatching { Sui.init(context.packageName) }.getOrDefault(false)
+    }
+
+    /**
+     * Shizuku / Sui 是否可用（binder 已连接且当前进程已被授权）。
+     * Sui 环境下 [Shizuku.checkSelfPermission] 恒为 DENIED，但 binder 已建立，直接视为就绪。
+     */
+    private fun isShizukuReady(): Boolean {
+        if (Sui.isSui()) return true
+        return runCatching {
+            val ping = Shizuku.pingBinder()
+            if (!ping) return false
+            Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+        }.getOrDefault(false)
+    }
+
+    /**
+     * 通过 Shizuku / Sui 强制停止目标应用。
+     * 利用 Shizuku/Sui 提供的高权限进程执行 `am force-stop`：Sui 下以 root 运行、
+     * Shizuku 下以 adb shell 运行，均等价于 root 但无需设备 root。
+     */
+    private fun forceStopViaShizuku(targetPackage: String): Boolean {
+        if (!isShizukuReady()) return false
+        return runCommandViaShizuku(arrayOf("am", "force-stop", targetPackage))
+    }
+
+    // Shizuku 13.x 将 newProcess 标记为 private（@RestrictTo(LIBRARY)），但运行时仍可用，
+    // 通过反射调用以获得高权限进程。
+    private fun runCommandViaShizuku(command: Array<String>): Boolean {
+        return runCatching {
+            val newProcess = Shizuku::class.java.getDeclaredMethod(
+                "newProcess",
+                Array<String>::class.java,
+                Array<String>::class.java,
+                String::class.java
+            ).apply { isAccessible = true }
+            val process = newProcess.invoke(null, command, null, null) as? Process
+            process?.waitFor() == 0
+        }.getOrDefault(false)
     }
 
     fun executeSuCommand(vararg commands: String): Result<Int> {
@@ -79,36 +129,100 @@ object RootUtils {
                 writer.flush()
             }
             val exitCode = process.waitFor()
-            if (exitCode == 0) {
-                exitCode
-            } else {
-                throw IllegalStateException("su exited with code $exitCode")
-            }
+            if (exitCode == 0) exitCode else throw IllegalStateException("su exited with code $exitCode")
         }
     }
+
+    private fun forceStopViaRoot(targetPackage: String): Boolean {
+        return executeSuCommand("am force-stop $targetPackage").isSuccess
+    }
+
+    // ---- 对外入口 ----
 
     fun restartBilibili(
         context: Context,
         prefs: SharedPreferences?,
-        callback: (success: Boolean, errorMessage: String?) -> Unit,
+        callback: (success: Boolean, errorMessage: String?, method: String?) -> Unit,
     ) {
         val targetPackage = resolveBilibiliPackage(context, prefs)
-        executor.execute {
-            val result = executeSuCommand("am force-stop $targetPackage")
-            val isSuccess = result.isSuccess
-            mainHandler.post {
-                if (isSuccess) {
-                    val launchIntent = context.packageManager.getLaunchIntentForPackage(targetPackage)
-                    if (launchIntent != null) {
-                        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        runCatching { context.startActivity(launchIntent) }
+        ensureSuiInitialized(context)
+
+        val shizukuPing = runCatching { Shizuku.pingBinder() }.getOrDefault(false)
+        val shizukuPerm = runCatching { Shizuku.checkSelfPermission() }.getOrDefault(PackageManager.PERMISSION_DENIED)
+        val shizukuNeedsAuth = shizukuPing && shizukuPerm != PackageManager.PERMISSION_GRANTED
+
+        if (shizukuNeedsAuth && context is Activity) {
+            runCatching {
+                Shizuku.addRequestPermissionResultListener(object : Shizuku.OnRequestPermissionResultListener {
+                    override fun onRequestPermissionResult(requestCode: Int, grantResult: Int) {
+                        val granted = grantResult == PackageManager.PERMISSION_GRANTED
+                        // 授权成功优先走 Shizuku/Sui；无论授权与否都兜底 Root (su)
+                        val viaShizuku = granted && forceStopViaShizuku(targetPackage)
+                        val effective = if (viaShizuku) true else forceStopViaRoot(targetPackage)
+                        val method = if (effective) (if (viaShizuku) "Shizuku/Sui" else "Root") else null
+                        finishRestart(context, effective, callback, targetPackage, method)
                     }
-                    callback(true, null)
+                })
+                Shizuku.requestPermission(SHIZUKU_REQUEST_CODE)
+            }.onFailure {
+                executor.execute {
+                    val ok = forceStopViaRoot(targetPackage)
+                    finishRestart(context, ok, callback, targetPackage, if (ok) "Root" else null)
+                }
+            }
+            return
+        }
+
+        executor.execute {
+            // 1) 优先尝试 Shizuku / Sui（二者共用同一 API）
+            var isSuccess = forceStopViaShizuku(targetPackage)
+            var method: String? = if (isSuccess) "Shizuku/Sui" else null
+            // 2) Shizuku / Sui 失败，再兜底 Root (su)
+            if (!isSuccess) {
+                isSuccess = forceStopViaRoot(targetPackage)
+                method = if (isSuccess) "Root" else null
+            }
+            val success = isSuccess
+            val usedMethod = method
+            mainHandler.post {
+                if (success) {
+                    launchAndCallback(context, targetPackage, callback, usedMethod)
                 } else {
-                    callback(false, result.exceptionOrNull()?.message)
+                    callback(false, "shizuku/sui 与 root 均未能强制停止 $targetPackage", null)
                 }
             }
         }
+    }
+
+    private fun finishRestart(
+        context: Context,
+        success: Boolean,
+        callback: (success: Boolean, errorMessage: String?, method: String?) -> Unit,
+        targetPackage: String,
+        method: String? = null,
+    ) {
+        mainHandler.post {
+            if (success) {
+                launchAndCallback(context, targetPackage, callback, method)
+            } else {
+                callback(false, "shizuku/sui 与 root 均未能强制停止 $targetPackage", null)
+            }
+        }
+    }
+
+    private fun launchAndCallback(
+        context: Context,
+        targetPackage: String,
+        callback: (success: Boolean, errorMessage: String?, method: String?) -> Unit,
+        method: String?,
+    ) {
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(targetPackage)
+        if (launchIntent != null) {
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            // 授权期间 SettingsActivity 可能已被销毁，必须用 applicationContext 启动
+            runCatching { context.applicationContext.startActivity(launchIntent) }
+        }
+        callback(true, null, method)
     }
 
     fun showRestartBilibiliDialog(
@@ -120,10 +234,16 @@ object RootUtils {
             .setTitle(R.string.restart_dialog_title)
             .setMessage(R.string.restart_dialog_message)
             .setPositiveButton(R.string.restart_dialog_confirm) { _, _ ->
-                Toast.makeText(activity, R.string.restart_in_progress, Toast.LENGTH_SHORT).show()
-                restartBilibili(activity, prefs) { success, _ ->
+                Toast.makeText(activity.applicationContext, R.string.restart_in_progress, Toast.LENGTH_SHORT).show()
+                restartBilibili(activity, prefs) { success, _, method ->
                     if (success) {
-                        Toast.makeText(activity, R.string.restart_success, Toast.LENGTH_SHORT).show()
+                        // 成功后会自动拉起哔哩哔哩，设置页被切到后台；
+                        // 必须用 applicationContext，否则依附于后台 Activity 的 toast 不显示。
+                        val text = if (method != null)
+                            String.format(activity.getString(R.string.restart_success), method)
+                        else
+                            activity.getString(R.string.restart_success)
+                        Toast.makeText(activity.applicationContext, text, Toast.LENGTH_LONG).show()
                         onRestartSuccess?.invoke()
                     } else {
                         AlertDialog.Builder(activity)

--- a/app/src/main/java/io/github/bbzq/RootUtils.kt
+++ b/app/src/main/java/io/github/bbzq/RootUtils.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
+import io.github.bbzq.utils.ReflectionUtils
 import java.io.File
 import java.util.concurrent.Executors
 import rikka.shizuku.Shizuku
@@ -99,18 +100,26 @@ object RootUtils {
         return runCommandViaShizuku(arrayOf("am", "force-stop", targetPackage))
     }
 
-    // Shizuku 13.x 将 newProcess 标记为 private（@RestrictTo(LIBRARY)），但运行时仍可用，
-    // 通过反射调用以获得高权限进程。
-    private fun runCommandViaShizuku(command: Array<String>): Boolean {
-        return runCatching {
-            val newProcess = Shizuku::class.java.getDeclaredMethod(
+    private val shizukuNewProcessMethod by lazy {
+        runCatching {
+            Shizuku::class.java.getDeclaredMethod(
                 "newProcess",
                 Array<String>::class.java,
                 Array<String>::class.java,
                 String::class.java
             ).apply { isAccessible = true }
-            val process = newProcess.invoke(null, command, null, null) as? Process
-            process?.waitFor() == 0
+        }.getOrNull()
+    }
+
+    // Shizuku 13.x 将 newProcess 标记为 private（@RestrictTo(LIBRARY)），但运行时仍可用，
+    // 通过反射调用以获得高权限进程。
+    private fun runCommandViaShizuku(command: Array<String>): Boolean {
+        return runCatching {
+            val method = shizukuNewProcessMethod ?: return false
+            val process = ReflectionUtils.safeInvoke(method, null, command, null, null) as? Process
+            val exitCode = process?.waitFor()
+            process?.destroy()
+            exitCode == 0
         }.getOrDefault(false)
     }
 
@@ -149,22 +158,29 @@ object RootUtils {
 
         val shizukuPing = runCatching { Shizuku.pingBinder() }.getOrDefault(false)
         val shizukuPerm = runCatching { Shizuku.checkSelfPermission() }.getOrDefault(PackageManager.PERMISSION_DENIED)
-        val shizukuNeedsAuth = shizukuPing && shizukuPerm != PackageManager.PERMISSION_GRANTED
+        val shizukuNeedsAuth = !Sui.isSui() && shizukuPing && shizukuPerm != PackageManager.PERMISSION_GRANTED
 
         if (shizukuNeedsAuth && context is Activity) {
-            runCatching {
-                Shizuku.addRequestPermissionResultListener(object : Shizuku.OnRequestPermissionResultListener {
-                    override fun onRequestPermissionResult(requestCode: Int, grantResult: Int) {
-                        val granted = grantResult == PackageManager.PERMISSION_GRANTED
-                        // 授权成功优先走 Shizuku/Sui；无论授权与否都兜底 Root (su)
+            val listener = object : Shizuku.OnRequestPermissionResultListener {
+                override fun onRequestPermissionResult(requestCode: Int, grantResult: Int) {
+                    if (requestCode != SHIZUKU_REQUEST_CODE) return
+                    runCatching { Shizuku.removeRequestPermissionResultListener(this) }
+                    val granted = grantResult == PackageManager.PERMISSION_GRANTED
+                    // 在后台线程执行，避免主线程在 waitFor 或 Root 弹窗授权时发生 ANR
+                    executor.execute {
                         val viaShizuku = granted && forceStopViaShizuku(targetPackage)
                         val effective = if (viaShizuku) true else forceStopViaRoot(targetPackage)
                         val method = if (effective) (if (viaShizuku) "Shizuku/Sui" else "Root") else null
                         finishRestart(context, effective, callback, targetPackage, method)
                     }
-                })
+                }
+            }
+
+            runCatching {
+                Shizuku.addRequestPermissionResultListener(listener)
                 Shizuku.requestPermission(SHIZUKU_REQUEST_CODE)
             }.onFailure {
+                runCatching { Shizuku.removeRequestPermissionResultListener(listener) }
                 executor.execute {
                     val ok = forceStopViaRoot(targetPackage)
                     finishRestart(context, ok, callback, targetPackage, if (ok) "Root" else null)
@@ -182,15 +198,7 @@ object RootUtils {
                 isSuccess = forceStopViaRoot(targetPackage)
                 method = if (isSuccess) "Root" else null
             }
-            val success = isSuccess
-            val usedMethod = method
-            mainHandler.post {
-                if (success) {
-                    launchAndCallback(context, targetPackage, callback, usedMethod)
-                } else {
-                    callback(false, "shizuku/sui 与 root 均未能强制停止 $targetPackage", null)
-                }
-            }
+            finishRestart(context, isSuccess, callback, targetPackage, method)
         }
     }
 
@@ -239,18 +247,21 @@ object RootUtils {
                     if (success) {
                         // 成功后会自动拉起哔哩哔哩，设置页被切到后台；
                         // 必须用 applicationContext，否则依附于后台 Activity 的 toast 不显示。
-                        val text = if (method != null)
+                        val text = if (!method.isNullOrBlank()) {
                             String.format(activity.getString(R.string.restart_success), method)
-                        else
-                            activity.getString(R.string.restart_success)
+                        } else {
+                            activity.getString(R.string.restart_success_fallback)
+                        }
                         Toast.makeText(activity.applicationContext, text, Toast.LENGTH_LONG).show()
                         onRestartSuccess?.invoke()
                     } else {
-                        AlertDialog.Builder(activity)
-                            .setTitle(R.string.restart_dialog_title)
-                            .setMessage(R.string.restart_failed_root_required)
-                            .setPositiveButton(android.R.string.ok, null)
-                            .show()
+                        if (!activity.isFinishing && !activity.isDestroyed) {
+                            AlertDialog.Builder(activity)
+                                .setTitle(R.string.restart_dialog_title)
+                                .setMessage(R.string.restart_failed_root_required)
+                                .setPositiveButton(android.R.string.ok, null)
+                                .show()
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,12 +416,12 @@
     <string name="video_detail_relate_type_unknown">未知分类 (%1$s)</string>
     <string name="toolbar_save_and_restart">保存并重启</string>
     <string name="action_restart_bilibili_title">保存并重启哔哩哔哩</string>
-    <string name="action_restart_bilibili_summary">使用 Root 权限强制停止并重新启动哔哩哔哩，使所有修改立即生效。</string>
+    <string name="action_restart_bilibili_summary">使用 Root 或 Shizuku 权限强制停止并重新启动哔哩哔哩，使所有修改立即生效。</string>
     <string name="restart_dialog_title">确认保存并重启哔哩哔哩</string>
-    <string name="restart_dialog_message">将使用 Root 权限强制停止并重新启动哔哩哔哩，以使所有模块设置立即生效。是否继续？</string>
+    <string name="restart_dialog_message">将使用 Root 或 Shizuku 权限强制停止并重新启动哔哩哔哩，以使所有模块设置立即生效。是否继续？</string>
     <string name="restart_dialog_confirm">确认重启</string>
     <string name="restart_in_progress">正在重新启动哔哩哔哩…</string>
-    <string name="restart_success">哔哩哔哩已重新启动</string>
-    <string name="restart_failed_root_required">获取 Root 权限失败，请确保设备已 Root 并在授权管理（Magisk / KernelSU / APatch）中允许 BBZQ 的 Root 权限。</string>
+    <string name="restart_success">已通过 %s 重启哔哩哔哩</string>
+    <string name="restart_failed_root_required">获取 Root 权限失败，请确保设备已 Root 并在授权管理（Magisk / KernelSU / APatch）中允许 BBZQ 的 Root 权限。如果您没有 Root 权限，Shizuku 也能提供强行停止应用的能力。</string>
     <string name="restart_failed_pkg_not_found">未找到已安装的哔哩哔哩客户端。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -422,6 +422,7 @@
     <string name="restart_dialog_confirm">确认重启</string>
     <string name="restart_in_progress">正在重新启动哔哩哔哩…</string>
     <string name="restart_success">已通过 %s 重启哔哩哔哩</string>
+    <string name="restart_success_fallback">哔哩哔哩已重新启动</string>
     <string name="restart_failed_root_required">获取 Root 权限失败，请确保设备已 Root 并在授权管理（Magisk / KernelSU / APatch）中允许 BBZQ 的 Root 权限。如果您没有 Root 权限，Shizuku 也能提供强行停止应用的能力。</string>
     <string name="restart_failed_pkg_not_found">未找到已安装的哔哩哔哩客户端。</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ activity = "1.12.4"
 constraintlayout = "2.2.1"
 okhttp = "5.3.2"
 dexkit = "2.2.0"
+shizukuApi = "13.1.5"
+shizukuProvider = "13.1.5"
 
 [libraries]
 libxposed-api = { module = "io.github.libxposed:api", version.ref = "libxposedApi" }
@@ -25,6 +27,8 @@ activity = { group = "androidx.activity", name = "activity", version.ref = "acti
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 dexkit = { group = "org.luckypray", name = "dexkit", version.ref = "dexkit" }
+shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizukuApi" }
+shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizukuProvider" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
为"重启哔哩哔哩"新增shizuku/sui支持：通过 Shizuku/Sui 的高权限进程执行 am force-stop 强制停止 bilibili 后重新拉起，使模块设置立即生效；无 Shizuku/Sui 时兜底 Root。

- 优先 Shizuku/Sui：反射调用 Shizuku 13.x 私有 newProcess 执行 am force-stop， Sui可以adbshell或root运行，Shizuku 下以 adb shell 运行且无需设备 root。
- 未授权时通过 requestPermission 弹窗授权；授权失败或非 Activity 场景兜底 Root。
- 成功时 toast 显示实际生效的方式（Shizuku/Sui 或 Root）。
- 依赖 dev.rikka.shizuku api/provider 13.1.5，并在 ProGuard 中保留 rikka.sui。
- 已在HyperOS 3.0.8.0，Sui v13.5.4测试成功。